### PR TITLE
fix gcc warnings on aimos

### DIFF
--- a/src/BoundExchange.cc
+++ b/src/BoundExchange.cc
@@ -31,7 +31,7 @@ void InitBoundaryDescr3D(BoundaryDescr3D &bdesc,Part3Mesh3D& p3m3d, Part1ParalPa
   }
 }
 
-void zPotentBoundaryBufAssign(MPI_Datatype mpitype,BoundaryDescr3D &bdesc,DatasProc3D& dp3d, Part3Mesh3D& p3m3d,\
+void zPotentBoundaryBufAssign(MPI_Datatype mpitype,BoundaryDescr3D &bdesc,DatasProc3D& dp3d, Part3Mesh3D& p3m3d,
      Part1ParalPar3D &p1pp3d)
 {
   if(bdesc.lowpotentz==NULL||bdesc.uppotentz==NULL){
@@ -50,11 +50,11 @@ void zPotentBoundaryBufAssign(MPI_Datatype mpitype,BoundaryDescr3D &bdesc,DatasP
          std::exit(EXIT_FAILURE);
        } 
       if(p1pp3d.periods[2]==1){ 
-        mpisendrecv_aux1D(mpitype,p1pp3d.comm_z,nzb,li0,lj0,lk0,bdesc.lowzpart3[i],bdesc.upzpart3[i], \
+        mpisendrecv_aux1D(mpitype,p1pp3d.comm_z,nzb,li0,lj0,lk0,bdesc.lowzpart3[i],bdesc.upzpart3[i],
           p3m3d.pzcoords[i]); 
         if(p1pp3d.comm_z==0) 
         for(LO j=0;j<lj0;j++){
-          mpisendrecv_aux1D(mpitype,p1pp3d.comm_z,nzb,li0,lj0,lk0,bdesc.lowpotentz[i][j],bdesc.uppotentz[i][j],\
+          mpisendrecv_aux1D(mpitype,p1pp3d.comm_z,nzb,li0,lj0,lk0,bdesc.lowpotentz[i][j],bdesc.uppotentz[i][j],
               dp3d.potentout[i][j]); 
         }
       } else {

--- a/src/dataprocess.h
+++ b/src/dataprocess.h
@@ -54,11 +54,11 @@ class BoundaryDescr3D{
 
 void InitBoundaryDescr3D(BoundaryDescr3D &bdesc,Part3Mesh3D& p3m3d, Part1ParalPar3D &p1pp3d,DatasProc3D& dp3d);
 
-void zPotentBoundaryBufAssign(MPI_Datatype mpitype,BoundaryDescr3D &bdesc,DatasProc3D& dp3d,\
+void zPotentBoundaryBufAssign(MPI_Datatype mpitype,BoundaryDescr3D &bdesc,DatasProc3D& dp3d,
         Part3Mesh3D& p3m3d, Part1ParalPar3D &p1pp3d);
 
   template<class T>
-void  zDensityBoundaryBufAssign(MPI_Datatype mpitype,LO nzb,LO lx,LO ly,LO lz,T*** lowbuf,\
+void  zDensityBoundaryBufAssign(MPI_Datatype mpitype,LO nzb,LO lx,LO ly,LO lz,T*** lowbuf,
        T*** upbuf,T*** box,Part1ParalPar3D &p1pp3d)
   {
    if(lowbuf==NULL||upbuf==NULL){
@@ -91,7 +91,7 @@ void  zDensityBoundaryBufAssign(MPI_Datatype mpitype,LO nzb,LO lx,LO ly,LO lz,T*
 
 
 template<class T>
-void mpisendrecv_aux2D(MPI_Datatype mpitype,MPI_Comm comm,LO nzb,LO lx,LO ly,LO lz,\
+void mpisendrecv_aux2D(MPI_Datatype mpitype,MPI_Comm comm,LO nzb,LO lx,LO ly,LO lz,
      T*** lowbuf,T*** upbuf,T*** box)
 {
       T* sendbuf=new T[lx*ly*nzb];
@@ -105,7 +105,7 @@ void mpisendrecv_aux2D(MPI_Datatype mpitype,MPI_Comm comm,LO nzb,LO lx,LO ly,LO 
            sendbuf[i*ly*nzb+j*nzb+k]=box[i][j][k];
        }
       }
-      MPI_Sendrecv(sendbuf,lx*ly*nzb,mpitype,rank_dest,100,recvbuf,lx*ly*nzb,mpitype,rank_source,101,\
+      MPI_Sendrecv(sendbuf,lx*ly*nzb,mpitype,rank_dest,100,recvbuf,lx*ly*nzb,mpitype,rank_source,101,
                   comm,&status);
       for(LO i=0;i<lx-1;i++){
        for(LO j=0;j<ly-1;j++){
@@ -120,7 +120,7 @@ void mpisendrecv_aux2D(MPI_Datatype mpitype,MPI_Comm comm,LO nzb,LO lx,LO ly,LO 
             sendbuf[i*ly*nzb+j*nzb+k]=box[i][j][lz-nzb+k];
        }
      }
-      MPI_Sendrecv(sendbuf,lx*ly*nzb,mpitype,&rank_dest,102,recvbuf,lx*ly*nzb,mpitype,&rank_source,103,\
+      MPI_Sendrecv(sendbuf,lx*ly*nzb,mpitype,&rank_dest,102,recvbuf,lx*ly*nzb,mpitype,&rank_source,103,
                   comm,&status);
       for(LO i=0;i<lx-1;i++){
        for(LO j=0;j<ly-1;j++){
@@ -133,16 +133,16 @@ void mpisendrecv_aux2D(MPI_Datatype mpitype,MPI_Comm comm,LO nzb,LO lx,LO ly,LO 
 }
 
 template<class T>
-void mpisendrecv_aux1D(MPI_Datatype mpitype,MPI_Comm comm,LO nzb,LO xind,LO yind,LO zind,\
+void mpisendrecv_aux1D(MPI_Datatype mpitype,MPI_Comm comm,LO nzb,LO xind,LO yind,LO zind,
      T* lowbuf,T* upbuf,T* box1d)
 {
       MPI_Status status;
       int rank_source, rank_dest;
       MPI_Cart_shift(comm,3,1,&rank_source,&rank_dest);
-      MPI_Sendrecv(box1d,nzb,mpitype,rank_dest,100,upbuf,nzb,mpitype,rank_source,101,\
+      MPI_Sendrecv(box1d,nzb,mpitype,rank_dest,100,upbuf,nzb,mpitype,rank_source,101,
             comm,&status);
       MPI_Cart_shift(comm,3,-1,&rank_source,&rank_dest);
-      MPI_Sendrecv(&box1d[zind-nzb],nzb,mpitype,rank_dest,102,lowbuf,nzb,mpitype,rank_source,103,\
+      MPI_Sendrecv(&box1d[zind-nzb],nzb,mpitype,rank_dest,102,lowbuf,nzb,mpitype,rank_source,103,
             comm,&status);
 }
 
@@ -153,7 +153,7 @@ void CmplxdataToRealdata3D(DatasProc3D& dp3d, Part1ParalPar3D& p1pp3d);
 
 void RealdataToCmplxdata3D(DatasProc3D& dp3d, Part1ParalPar3D& p1pp3d,Part3Mesh3D &p3m3d);
 
-void TransposeComplex(std::complex<double>** InMatrix,std::complex<double>** OutMatrix, DatasProc3D& dp3d,\
+void TransposeComplex(std::complex<double>** InMatrix,std::complex<double>** OutMatrix, DatasProc3D& dp3d,
      Part1ParalPar3D& p1pp3d);
 
 void ExecuteCmplxToReal(DatasProc3D& dp3d, Part1ParalPar3D& p1pp3d);
@@ -207,10 +207,10 @@ void Lag3dArray(T* yin,double* xin,LO nin,T* yout,double* xout,LO nout){
 
      }
 
-void InterpoDensity3D(BoundaryDescr3D &bdesc,Part3Mesh3D& p3m3d,\  
+void InterpoDensity3D(BoundaryDescr3D &bdesc,Part3Mesh3D& p3m3d,  
      Part1ParalPar3D &p1pp3d,DatasProc3D& dp3d);
 
-void InterpoPotential3D(BoundaryDescr3D &bdesc,Part3Mesh3D& p3m3d,\
+void InterpoPotential3D(BoundaryDescr3D &bdesc,Part3Mesh3D& p3m3d,
      Part1ParalPar3D &p1pp3d,DatasProc3D& dp3d);
 
 }

--- a/src/fourierdataproc.cc
+++ b/src/fourierdataproc.cc
@@ -72,7 +72,7 @@ void RealdataToCmplxdata3D(DatasProc3D& dp3d, Part1ParalPar3D& p1pp3d,Part3Mesh3
 
 // This routine is not required in first verion of coupler, but would be modifed 
 // for in the 2nd version. Here, the indexes may need exchange. 
-void TransposeComplex(std::complex<double>** InMatrix,std::complex<double>** OutMatrix, DatasProc3D& dp3d, \
+void TransposeComplex(std::complex<double>** InMatrix,std::complex<double>** OutMatrix, DatasProc3D& dp3d,
      Part1ParalPar3D& p1pp3d)
 {
   std::complex<double>*** sbuf;
@@ -120,9 +120,9 @@ void ExecuteRealToCmplx(DatasProc3D& dp3d, Part1ParalPar3D& p1pp3d)
 void InitFourierPlan3D( DatasProc3D& dp3d,Part1ParalPar3D& p1pp3d, Part3Mesh3D &p3m3d)
 { 
   if(dp3d.yparal==true){
-    dp3d.plan_backward=fftw_plan_dft_c2r_2d(p1pp3d.li0*p1pp3d.lk0, p1pp3d.lj0,\
+    dp3d.plan_backward=fftw_plan_dft_c2r_2d(p1pp3d.li0*p1pp3d.lk0, p1pp3d.lj0,
                        reinterpret_cast<fftw_complex*>(dp3d.densintmp),dp3d.densouttmp,FFTW_BACKWARD); 
-    dp3d.plan_forward=fftw_plan_dft_r2c_2d(dp3d.sum, p3m3d.lj0,dp3d.potentintmp, \
+    dp3d.plan_forward=fftw_plan_dft_r2c_2d(dp3d.sum, p3m3d.lj0,dp3d.potentintmp,
                       reinterpret_cast<fftw_complex*>(dp3d.potentouttmp),FFTW_ESTIMATE);
   }
 }

--- a/src/importpart3mesh.cc
+++ b/src/importpart3mesh.cc
@@ -34,7 +34,7 @@ void ImportPart3Mesh3D(Part3Mesh3D &p3m3d, Part1ParalPar3D  &p1pp3d)
      MPI_Bcast(p3m3d.xcoords,numsurf,MPI_DOUBLE,root,MPI_COMM_WORLD);
     if(preproc==true){
      if(p3m3d.nsurf != p1pp3d.nx0)
-     {std::cout<<"Error: The number of surface of Part3 doesn't equal to the number vertice of x domain of part1. " \ 
+     {std::cout<<"Error: The number of surface of Part3 doesn't equal to the number vertice of x domain of part1. "
                <<"\n"<<std::endl;
        std::exit(EXIT_FAILURE);
      }
@@ -183,7 +183,7 @@ void DistributePoints(double* exterarr,LO gstart,LO li, double* interarr,Part3Me
     p3m3d.mylk0[li-gstart]=i2-i1+1;
     if(test_case==0){   
       std::cout<<"rank="<<p1pp3d.mype<<" "<<li-gstart<<'\n';
-      std::cout<<"mylk k="<<p3m3d.mylk0[li-gstart]<<" "<<p3m3d.mylk1[li-gstart] \
+      std::cout<<"mylk k="<<p3m3d.mylk0[li-gstart]<<" "<<p3m3d.mylk1[li-gstart]
       <<" "<<p3m3d.mylk2[li-gstart]<<" "<<'\n'; 
     }
   }

--- a/src/importpart3mesh.h
+++ b/src/importpart3mesh.h
@@ -41,7 +41,7 @@ LO  minloc(const double* zcoords, const LO n);
 
 void reshuffle_nodes(double* zcoords,const LO nstart,const LO vertnum);
 
-void DistributePoints(double* exterarr,LO gstart,LO li, double* interarr,Part3Mesh3D &p3m3d,  \
+void DistributePoints(double* exterarr,LO gstart,LO li, double* interarr,Part3Mesh3D &p3m3d,
      Part1ParalPar3D  &p1pp3d);
 
 double minimalvalue(const double* array, const LO n);


### PR DESCRIPTION
Trailing backslashes are not required in C++.  Some caused compiler warnings on aimos with gcc7.4:

```
[ 23%] Building CXX object src/CMakeFiles/coupler.dir/importpart3mesh.cc.o
/gpfs/u/barn/MPFS/MPFSsmth/wdmapp_coupling/src/importpart3mesh.cc:37:117: warning: backslash and newline separated by space
      {std::cout<<"Error: The number of surface of Part3 doesn't equal to the number vertice of x domain of part1. " \
```