### PR TITLE
fix linking to MPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,13 @@
 cmake_minimum_required(VERSION 3.13)
 project(wdm_coupling VERSION 0.0.1 LANGUAGES CXX)
+
+set(MPI_CXX_SKIP_MPICXX ON)
+find_package(MPI REQUIRED)
+
 #adios2 adds C and Fortran depending on how it was built
 find_package(ADIOS2 2.5 REQUIRED)
 find_package(Kokkos 3.0 REQUIRED)
+
 ## use pkgconfig since the fftw autoconf install produces
 ## broken cmake config files
 ## https://github.com/FFTW/fftw3/issues/130

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(HEADERS coupling.h couplingConstants.h)
 
 add_library(coupler ${SOURCES})
 set_target_properties(coupler PROPERTIES PUBLIC_HEADER "${HEADERS}")
-target_link_libraries(coupler adios2::adios2 Kokkos::kokkos PkgConfig::fftw)
+target_link_libraries(coupler adios2::adios2 Kokkos::kokkos PkgConfig::fftw MPI::MPI_CXX)
 
 add_executable(cpl cpl.cc)
 target_link_libraries(cpl coupler)


### PR DESCRIPTION
This is a proposed fix for #40.
In my Ubuntu image, I got undefined references to the C++ MPI bindings,
which are fixed with this PR.

I don't know if this is going to be give you troubles, but the cmake builds for XGC1, GENE, XGC-Devel, ADIOS2 etc all use `find_package(MPI)`, so if something is broken with that, I'd say it's worth looking into what's actually going wrong.