### PR TITLE
mpi_cart_shift dimension

### DIFF
--- a/src/sendrecv_impl.h
+++ b/src/sendrecv_impl.h
@@ -41,7 +41,7 @@ void mpisendrecv_aux2D(MPI_Comm comm,LO nzb,LO lx,LO ly,LO lz,
       T* recvbuf=new T[lx*ly*nzb];
       MPI_Status status;
       int rank_source,rank_dest;
-      MPI_Cart_shift(comm,2,1,&rank_source,&rank_dest);
+      MPI_Cart_shift(comm,0,1,&rank_source,&rank_dest);
       for(LO i=0;i<lx;i++){
        for(LO j=0;j<ly;j++){
          for(LO k=0;k<nzb;k++)
@@ -56,20 +56,7 @@ void mpisendrecv_aux2D(MPI_Comm comm,LO nzb,LO lx,LO ly,LO lz,
               upbuf[i][j][k]=recvbuf[i*ly*nzb+j*nzb+k];
        }
       }
-/*
-int rank;
-MPI_Comm_rank(MPI_COMM_WORLD,&rank);
-if(rank==0){
-  for(int i=0;i<lx;i++){
-  for(int j=0;j<ly;j++){
-  for(int h=0;h<nzb;h++){
-    std::cout<<"upbuf="<<upbuf[i][j][h]<<'\n';
-  }
-  }
-  }
-}
-*/
-      MPI_Cart_shift(comm,2,-1, &rank_source, &rank_dest);
+      MPI_Cart_shift(comm,0,-1, &rank_source, &rank_dest);
       for(LO i=0;i<lx;i++){
        for(LO j=0;j<ly;j++){
          for(LO k=0;k<nzb;k++)
@@ -96,10 +83,10 @@ void mpisendrecv_aux1D(MPI_Comm comm,LO nzb,LO xind,LO yind,LO zind,
       MPI_Datatype mpitype = getMpiType(T());
       MPI_Status status;
       int rank_source, rank_dest;
-      MPI_Cart_shift(comm,3,1,&rank_source,&rank_dest);
+      MPI_Cart_shift(comm,0,1,&rank_source,&rank_dest);
       MPI_Sendrecv(box1d,nzb,mpitype,rank_dest,100,upbuf,nzb,mpitype,rank_source,100,
             comm,&status);
-      MPI_Cart_shift(comm,3,-1,&rank_source,&rank_dest);
+      MPI_Cart_shift(comm,0,-1,&rank_source,&rank_dest);
       MPI_Sendrecv(&box1d[zind-nzb],nzb,mpitype,rank_dest,102,lowbuf,nzb,mpitype,rank_source,102,
             comm,&status);
 }


### PR DESCRIPTION
When attempting to run `test_init` on a SCOREC RHEL7 system with MPICH 3.3.1 the following error was generated:

```
$ ctest -V
<....>
Start testing: May 20 11:20 EDT
----------------------------------------------------------
1/1 Testing: t0
1/1 Test: t0
Command: "/opt/scorec/spack/dev/install/linux-rhel7-x86_64/gcc-7.4.0/mpich-3.3.1-bfezl2lt55nkqq3x7o5364rlvbknynka/bin/mpirun" "-np" "4" "/lore/cwsmith/develop/build-wdmCoupler-rhel7/bin/test_init" "/lore/cwsmith/develop/wdmapp_coupling_data/testdatas/"
Directory: /lore/cwsmith/develop/build-wdmCoupler-rhel7/test
<...>
rank=0 1
mylk k=11 0 10
Fatal error in PMPI_Cart_shift: Invalid argument, error stack:
PMPI_Cart_shift(182)....: MPI_Cart_shift(comm=0xc4000003, direction=3, displ=1, source=0x7ffd6d8d732c, dest=0x7ffd6d8d7328) failed
PMPI_Cart_shift(169)....:
MPIR_Cart_shift_impl(48): Number of dimensions 1 is too large (maximum is 3)
```

The helper function `mpisendrecv_aux1D` and `mpisendrecv_aux2D` are currently only called with the `p1pp3d.comm_z` communicator, 

```
$ grep mpisendrecv_aux src/* | grep -v sendrecv_impl
BoundaryDescr3D.cc:        mpisendrecv_aux1D(p1pp3d.comm_z,nzb,li0,lj0,lk0,lowzpart3[i],upzpart3[i],
BoundaryDescr3D.cc:          mpisendrecv_aux1D(p1pp3d.comm_z,nzb,li0,lj0,lk0,lowpotentz[i][j],uppotentz[i][j], 
dataprocess_impl.h:      mpisendrecv_aux2D(p1pp3d.comm_z, nzb, lx, ly, lz, lowbuf, upbuf, box);
```

which from my understanding of this code:

https://github.com/SCOREC/wdmapp_coupling/blob/7aa8670f2899ba3a493e8592f0be33005d7c4591/src/commpart1.cc#L123-L134

contain only one dimension, `z`, of the cartesian MPI communicator.

Assuming my understanding is correct, the fix is to change the `dimension` argument to `MPI_Cart_shift` to `0` (see the PR file diff).

With this change the output of `test_init` matches the output from AiMOS without the change.  For some reason, Spectrum MPI (based on OpenMPI) on AiMOS does not complain about the dimension input to `MPI_Cart_shift` being larger than the dimensions in the specified communicator.

