### PR TITLE
Class init

### DIFF
--- a/src/commpart1.cc
+++ b/src/commpart1.cc
@@ -46,7 +46,7 @@ void Part1ParalPar3D::initTest0(std::string test_dir)
 }
 
 //read the paralllization parameters
-void Part1ParalPar3D::init(LO* parpar, double* xzcoords, double* q_prof, std::string test_dir)
+void Part1ParalPar3D::init(LO* parpar, double* xzcoords, double* q_prof, double* gene_cy, std::string test_dir)
 {
  if(preproc==true){ 
    if(test_case==TestCase::t0){
@@ -58,6 +58,7 @@ void Part1ParalPar3D::init(LO* parpar, double* xzcoords, double* q_prof, std::st
    }else{
      assert(parpar);
      assert(q_prof);
+     assert(gene_cy);
      npx=parpar[0];
      nx0=parpar[1];
      nxb=parpar[2];
@@ -101,6 +102,13 @@ void Part1ParalPar3D::init(LO* parpar, double* xzcoords, double* q_prof, std::st
    // initialize the radial locations of the flux surface and poloidal angles
    pzcoords=new double[nz0];
    xcoords=new double[nx0];
+
+    
+   C_y = gene_cy;
+   minor_r = gene_cy[nx0];
+   lx_a = gene_cy[nx0+1];
+   sign_phi = gene_cy[nx0+2];
+   dx = gene_cy[nx0+3];
 
 // The two lines will be needed when refactoring this part code.
 //   double* xzcoords;

--- a/src/commpart1.h
+++ b/src/commpart1.h
@@ -62,11 +62,12 @@ class Part1ParalPar3D {
     Part1ParalPar3D(LO * parpar, 
         double* xzcoords,
         double* q_prof_,
+        double* gene_cy,
 	bool pproc = true,
         std::string tdir="")
-      : preproc(pproc),q_prof(q_prof_), 
+      : preproc(pproc),q_prof(q_prof_),
         test_case(TestCase::off){
-      init(parpar, xzcoords, q_prof, tdir);
+      init(parpar, xzcoords, q_prof, gene_cy, tdir);
       if(!mype) std::cerr << mype << " Done with Part1ParalPar3D class intialization \n"; 
     }
     /*Test case constructor*/
@@ -74,7 +75,7 @@ class Part1ParalPar3D {
         TestCase tcase,
       	std::string tdir)
       : preproc(pproc), test_case(tcase){
-      init(NULL, NULL, NULL, tdir);
+      init(NULL, NULL, NULL, NULL, tdir);
     }
     ~Part1ParalPar3D()
     {
@@ -87,7 +88,7 @@ class Part1ParalPar3D {
   private:
     const bool preproc;
     const TestCase test_case;
-    void init(LO* parpar, double* xzcoords, double* q_prof, std::string test_dir="");
+    void init(LO* parpar, double* xzcoords, double* q_prof, double* gene_cy, std::string test_dir="");
     void initTest0(std::string test_dir);
     /* init* helper function */
     void CreateSubCommunicators();

--- a/test/cpl.cc
+++ b/test/cpl.cc
@@ -63,14 +63,8 @@ int main(int argc, char **argv){
   const bool preproc = true;
   const bool ypar = false;
   coupler::TestCase test_case = coupler::TestCase::off;
-  coupler::Part1ParalPar3D p1pp3d(gene_parpar->data(),gene_xval->data(),q_prof->data(),preproc);
-
   coupler::Array1d<double>* gene_cy = coupler::receive_gene_pproc<double>(dir, gCy);
-  double* C_y = gene_cy->data();
-  double minor_r = gene_cy->val(p1pp3d.nx0);
-  double lx_a = gene_cy->val(p1pp3d.nx0+1);
-  double sign_phi = gene_cy->val(p1pp3d.nx0+2);
-  double dx = gene_cy->val(p1pp3d.nx0+3);
+  coupler::Part1ParalPar3D p1pp3d(gene_parpar->data(),gene_xval->data(),q_prof->data(), gene_cy->data(), preproc);
 
 
   //receive XGC's preproc mesh discretization values


### PR DESCRIPTION
This PR includes codes in the coupler to do the following:

- Receive the `cy_array`
- Use the received values within the `cy_array` to initialize related variables in the commpart1 class.