### PR TITLE
removing MPI_Barrier from coupler Perfstubs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "perfstubs"]
+	path = perfstubs
+	url = https://github.com/khuck/perfstubs.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "perfstubs"]
-	path = perfstubs
-	url = https://github.com/khuck/perfstubs.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(MPI REQUIRED)
 #adios2 adds C and Fortran depending on how it was built
 find_package(ADIOS2 2.5 REQUIRED)
 find_package(Kokkos 3.0 REQUIRED)
+
 ## use pkgconfig since the fftw autoconf install produces
 ## broken cmake config files
 ## https://github.com/FFTW/fftw3/issues/130
@@ -29,4 +30,3 @@ endif()
 
 add_subdirectory(src)
 add_subdirectory(test)
-add_subdirectory(perfstubs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,3 +29,4 @@ endif()
 
 add_subdirectory(src)
 add_subdirectory(test)
+add_subdirectory(perfstubs)

--- a/src/BoundaryDescr3D.cc
+++ b/src/BoundaryDescr3D.cc
@@ -16,6 +16,7 @@ BoundaryDescr3D::BoundaryDescr3D(
     const TestCase tcase,
     bool pproc):test_case(tcase), preproc(pproc)
 {
+  PERFSTUBS_START_STRING(__func__);
   if(preproc==true){
     nzb=p1pp3d.nzb;
     updenz=new CV**[p1pp3d.li0];
@@ -62,10 +63,12 @@ BoundaryDescr3D::BoundaryDescr3D(
 
    initpbmat(p1pp3d);
   } 
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 void BoundaryDescr3D::initpbmat(const Part1ParalPar3D &p1pp3d)
 {
+   PERFSTUBS_START_STRING(__func__);
    LO num;
    if(p1pp3d.mype_z==0){
      for(LO i=0;i<p1pp3d.li0;i++){
@@ -84,17 +87,20 @@ void BoundaryDescr3D::initpbmat(const Part1ParalPar3D &p1pp3d)
        }
      }
    }
+   PERFSTUBS_STOP_STRING(__func__);
 }
 
 
 BoundaryDescr3D::~BoundaryDescr3D()
 {
+  PERFSTUBS_START_STRING(__func__);
   if(upzpart3!=NULL) delete[] upzpart3;
   if(lowzpart3!=NULL) delete[] lowzpart3;
   if(updenz!=NULL) delete[] updenz;
   if(lowdenz!=NULL) delete[] lowdenz;
   if(uppotentz!=NULL) delete[] uppotentz;
   if(lowpotentz!=NULL) delete[] lowpotentz;
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 

--- a/src/adios2Routines.cc
+++ b/src/adios2Routines.cc
@@ -11,6 +11,7 @@ namespace coupler {
 
   void send_density(const std::string cce_folder, const Array2d<double>* density,
       const adios2_handler &handler, adios2::Variable<double> &send_id) {
+    PERFSTUBS_START_STRING(__func__);
     adios2::IO io = handler.IO; 
     adios2::Engine engine = handler.eng;
     int rank;
@@ -18,6 +19,7 @@ namespace coupler {
     const std::string fld_name = "cpl_density";
     send2d_from_C(density, cce_folder, fld_name, io, engine, send_id);
     std::cerr << rank <<  ": send " << fld_name <<" done \n";
+    PERFSTUBS_STOP_STRING(__func__);
   }
 
   Array2d<double>* receive_field(const std::string cce_folder,
@@ -28,6 +30,7 @@ namespace coupler {
 
   void send_field(const std::string cce_folder, const Array2d<CV>* field,
       const adios2_handler &handler, adios2::Variable<CV> &send_id) {
+    PERFSTUBS_START_STRING(__func__);
     adios2::IO io = handler.IO; 
     adios2::Engine engine = handler.eng;
     int rank;
@@ -35,6 +38,7 @@ namespace coupler {
     const std::string fld_name = "cpl_field";
     send2d_from_C(field, cce_folder, fld_name, io, engine, send_id);
     std::cerr << rank <<  ": send " << fld_name <<" done \n";
+    PERFSTUBS_STOP_STRING(__func__);
   }
  
  void AdiosProTransFortranCpp2D(LO rankout,LO mypxout,LO mypyout, const LO mypex,const LO mypey,const LO npx,const LO npy)

--- a/src/adios2Routines.h
+++ b/src/adios2Routines.h
@@ -10,7 +10,7 @@
 #include <fstream>
 #include "couplingConstants.h" //not used
 #include "couplingTypes.h"
-#include "../perfstubs/perfstubs_api/timer.h"
+#include "perfstubs_api/timer.h"
 
 namespace coupler { 
       

--- a/src/adios2Routines.h
+++ b/src/adios2Routines.h
@@ -10,6 +10,7 @@
 #include <fstream>
 #include "couplingConstants.h" //not used
 #include "couplingTypes.h"
+#include "../perfstubs/perfstubs_api/timer.h"
 
 namespace coupler { 
       
@@ -144,6 +145,7 @@ namespace coupler {
   template<typename T> 
   Array1d<T>* receive1d_from_ftn(const std::string dir, const std::string name,
       adios2::IO &read_io, adios2::Engine &eng) {
+    PERFSTUBS_START_STRING(__func__);
     int rank, nprocs;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
@@ -184,6 +186,7 @@ namespace coupler {
     adios_var.SetSelection(sel);
     eng.Get(adios_var, field->data());
     eng.EndStep();
+    PERFSTUBS_STOP_STRING(__func__);
     return field;
   }
   
@@ -191,6 +194,7 @@ namespace coupler {
   template<typename T> 
   T* receive1d_exact_ftn(const std::string dir, const std::string name,
       adios2::IO &read_io, adios2::Engine &eng, GO li1, GO li0, MPI_Comm &comm) {
+    PERFSTUBS_START_STRING(__func__);
     int rank, nprocs;
     MPI_Comm_rank(comm, &rank);
     MPI_Comm_size(comm, &nprocs);
@@ -228,6 +232,7 @@ namespace coupler {
     adios_var.SetSelection(sel);
     eng.Get(adios_var, val);
     eng.EndStep();
+    PERFSTUBS_STOP_STRING(__func__);
     return val;
   } 
   
@@ -236,6 +241,7 @@ namespace coupler {
   template<typename T>
   Array2d<T>* receive2d_from_ftn(const std::string dir, const std::string name,
       adios2::IO &read_io, adios2::Engine &eng, GO start[2], GO count[2],MPI_Comm &comm,const int m) {
+    PERFSTUBS_START_STRING(__func__);
     int rank, nprocs;
     MPI_Comm_rank(comm, &rank);
     MPI_Comm_size(comm, &nprocs);
@@ -280,6 +286,7 @@ namespace coupler {
     eng.Get<T>(adVar, a2d->data());
     eng.EndStep();
     std::cerr << rank <<  ": receive " << name << " done \n";
+    PERFSTUBS_STOP_STRING(__func__);
     return a2d;
   }
   
@@ -289,6 +296,7 @@ namespace coupler {
       const std::string name, adios2::IO coupling_io,adios2::Engine engine,
       adios2::Variable<T> &send_id) 
 {
+    PERFSTUBS_START_STRING(__func__);
     const::adios2::Dims g_dims({a2d->globalW(), a2d->globalH()});
     const::adios2::Dims g_offset({0,a2d->start_col()});
     const::adios2::Dims l_dims({a2d->localW(), a2d->localH()});
@@ -307,6 +315,7 @@ namespace coupler {
     engine.Put<T>(send_id, a2d->data());
     engine.EndStep();
     std::cout<<"The cpl_density was written"<<'\n';
+    PERFSTUBS_STOP_STRING(__func__);
  }
   
   /** Receive PreProc values from GENE
@@ -330,6 +339,7 @@ template<typename T>
         const Array2d<T>* a2d, adios2::IO& sendIO,adios2::Engine& engine,const std::string fldname,                        
         adios2::Variable<T> &send_id, const MPI_Comm comm,const int m)  //     
  {
+    PERFSTUBS_START_STRING(__func__);
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     const std::string fld_name;
@@ -355,6 +365,7 @@ template<typename T>
     engine.Put<T>(send_id, a2d->data());
     engine.EndStep();
     std::cout<<"rank="<<rank<<" "<<"The "<<fldname<<" was written"<<'\n';
+    PERFSTUBS_STOP_STRING(__func__);
   }
   
 

--- a/src/boundbuffer.cc
+++ b/src/boundbuffer.cc
@@ -14,6 +14,7 @@ namespace coupler{
 // In the wdm/app(cuda_under_hood) the parallel boundary condition is not used for the potential.
 void DatasProc3D::zPotentBoundaryBufAssign(const BoundaryDescr3D& bdesc)
 {
+  PERFSTUBS_START_STRING(__func__);
   LO nzb=bdesc.nzb;
   if(bdesc.lowpotentz==NULL||bdesc.uppotentz==NULL){
     std::cout<<"ERROR:the boundary buffer of the potential must be allocated beforing invoking this routine.";
@@ -114,12 +115,14 @@ void DatasProc3D::zPotentBoundaryBufAssign(const BoundaryDescr3D& bdesc)
          std::exit(EXIT_FAILURE);
       }
    }
+   PERFSTUBS_STOP_STRING(__func__);
 }
 
 
 
 void DatasProc3D::zDensityBoundaryBufAssign(CV*** box,const BoundaryDescr3D& bdesc) 
 {
+  PERFSTUBS_START_STRING(__func__);
   LO nzb=bdesc.nzb;
   if (bdesc.lowdenz == NULL || bdesc.updenz == NULL) {
     std::cout << "ERROR:the boundary buffer must be alloctted before "
@@ -183,6 +186,7 @@ void DatasProc3D::zDensityBoundaryBufAssign(CV*** box,const BoundaryDescr3D& bde
       std::exit(EXIT_FAILURE);
     }
   }
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 

--- a/src/commpart1.cc
+++ b/src/commpart1.cc
@@ -5,6 +5,7 @@ namespace coupler {
 
 void Part1ParalPar3D::initTest0(std::string test_dir)
 {
+  PERFSTUBS_START_STRING(__func__);
   assert(!test_dir.empty());
   LO* data=new LO[12];
   std::string fname=test_dir+"parpart1.nml";
@@ -43,11 +44,13 @@ void Part1ParalPar3D::initTest0(std::string test_dir)
   fname=test_dir+"q_prof.nml";
   InputfromFile(q_prof,nx0,fname);
   
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 //read the paralllization parameters
 void Part1ParalPar3D::init(LO* parpar, double* xzcoords, double* q_prof, double* gene_cy, std::string test_dir)
 {
+ PERFSTUBS_START_STRING(__func__);
  if(preproc==true){ 
    if(test_case==TestCase::t0){
      assert(!parpar && !xzcoords && !q_prof);//when not testing, arrays come from ADIOS2
@@ -186,10 +189,12 @@ void Part1ParalPar3D::init(LO* parpar, double* xzcoords, double* q_prof, double*
      delete[] xzcoords;
    }
  }
+ PERFSTUBS_STOP_STRING(__func__);
 }
 
 void Part1ParalPar3D::CreateSubCommunicators()
 {
+   PERFSTUBS_START_STRING(__func__);
    // create 3D parallel cart with z being periodic
    int rorder = 0;
    int dim[3]={(int)npx,(int)npy,(int)npz};
@@ -210,22 +215,26 @@ void Part1ParalPar3D::CreateSubCommunicators()
    MPI_Comm_rank(comm_x,&mype_x);
    MPI_Comm_rank(comm_y,&mype_y);
    MPI_Comm_rank(comm_z,&mype_z);
+   PERFSTUBS_STOP_STRING(__func__);
 }
 
 void Part1ParalPar3D::MpiFreeComm()
 {
+  PERFSTUBS_START_STRING(__func__);
   MPI_Comm_free(&comm_x);
   MPI_Comm_free(&comm_y);
   MPI_Comm_free(&comm_z);
   MPI_Comm_free(&comm_cart);
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 void Part1ParalPar3D::blockindice()
 {
+   PERFSTUBS_START_STRING(__func__);
    blockcount = GO(nz0*li0);
    blockstart = GO(nz0*li1);
    blockend = GO(nz0*(li2+1)-1);
-
+   PERFSTUBS_STOP_STRING(__func__);
 }
 
 

--- a/src/dataprocess.cc
+++ b/src/dataprocess.cc
@@ -494,7 +494,6 @@ void DatasProc3D::AssemDensiSendtoPart3(BoundaryDescr3D& bdesc)
   bool debug=false;
   if(debug){
     printminmax(densinterpo,p1->li0,p1->lj0,p3->mylk0,p1->mype,"densinterpo",0);
-    MPI_Barrier(MPI_COMM_WORLD);
     CV sum=CV(0.0,0.0);
     printSumm3D(densinterpo,p1->li0,p1->lj0,p3->mylk0,sum,
     MPI_COMM_WORLD,"densinterpo",0);

--- a/src/dataprocess.cc
+++ b/src/dataprocess.cc
@@ -33,6 +33,7 @@ DatasProc3D::DatasProc3D(const Part1ParalPar3D* p1pp3d,
 
 void DatasProc3D::init()
 {
+  PERFSTUBS_START_STRING(__func__);
   if(preproc==true){
     if(yparal==true){
       if(p1->li0%p1->npy==0){
@@ -59,10 +60,12 @@ void DatasProc3D::init()
   sum=0;
   for(LO i=0;i<p3->li0;i++)  sum+=p3->mylk0[i];
  
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 void DatasProc3D::AllocDensityArrays()
 {
+  PERFSTUBS_START_STRING(__func__);
   if(yparal==false){
     densin=new CV**[p1->li0];
     for(LO i=0;i<p1->li0;i++){
@@ -98,11 +101,13 @@ void DatasProc3D::AllocDensityArrays()
    denssend = new double[p3->blockcount*p3->lj0];
    
  } 
+ PERFSTUBS_STOP_STRING(__func__);
 }
 
 
 void DatasProc3D::AllocPotentArrays()
-{ 
+{
+  PERFSTUBS_START_STRING(__func__);
   if(yparal==false){
     potentin=new double**[p3->li0];
     for(LO i=0;i<p3->li0;i++){
@@ -132,10 +137,12 @@ void DatasProc3D::AllocPotentArrays()
    potentsend = new CV[p1->blockcount*p1->lj0];
   
   }
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 void DatasProc3D::AllocMatXYZtoPlane()
 {
+   PERFSTUBS_START_STRING(__func__);
    mattoplane=new double***[p3->li0];
    for(LO i=0;i<p3->li0;i++){
      mattoplane[i] = new double**[p1->n_cuts];
@@ -176,10 +183,12 @@ void DatasProc3D::AllocMatXYZtoPlane()
       }
     }
   }
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 void DatasProc3D::DistriPotentRecvfromPart3(const Array2d<double>* fieldfromXGC)
-{ 
+{
+  PERFSTUBS_START_STRING(__func__);
   double** tmp;
   tmp = new double*[p3->lj0];
   for(LO j=0;j<p3->lj0;j++){
@@ -247,13 +256,15 @@ void DatasProc3D::DistriPotentRecvfromPart3(const Array2d<double>* fieldfromXGC)
     free(tmp[j]);
   free(tmp);
   tmp=NULL;
- } 
+  PERFSTUBS_STOP_STRING(__func__);
+}
 
 
 
 //Distribute the sub global potential  2d array received from part3 and reorder the sub 2darray.  
 void DatasProc3D::oldDistriPotentRecvfromPart3(const Array2d<double>* fieldfromXGC)
-{ 
+{
+  PERFSTUBS_START_STRING(__func__);
   double** tmp;
   tmp = new double*[p3->lj0];
   for(LO j=0;j<p3->lj0;j++){
@@ -289,12 +300,14 @@ void DatasProc3D::oldDistriPotentRecvfromPart3(const Array2d<double>* fieldfromX
   for(LO j=0;j<p3->lj0;j++)
     free(tmp[j]);
   free(tmp);
- } 
+  PERFSTUBS_STOP_STRING(__func__);
+}
 
 // Assemble the potential sub2d array in each process into a bigger one, which is straightforwardly transferred by
 // the adios2 API from coupler to Part1.
 void DatasProc3D::AssemPotentSendtoPart1()
 {
+  PERFSTUBS_START_STRING(__func__);
   LO* recvcount = new LO[p1->npz];
   LO* rdispls = new LO[p1->npz];
 
@@ -338,11 +351,13 @@ void DatasProc3D::AssemPotentSendtoPart1()
   tmp=NULL;
   recvcount=NULL;
   rdispls=NULL;
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 ////Distribute the subglobal density  2d array received from part1 to the processes.
 void DatasProc3D::DistriDensiRecvfromPart1(const Array2d<CV>* densityfromGENE)
 {
+  PERFSTUBS_START_STRING(__func__);
   CV** tmp; 
   tmp = new CV*[p1->lj0];
   for(LO j=0;j<p1->lj0; j++){
@@ -388,12 +403,14 @@ void DatasProc3D::DistriDensiRecvfromPart1(const Array2d<CV>* densityfromGENE)
    }  
    free(tmp);
    tmp=NULL;
+   PERFSTUBS_STOP_STRING(__func__);
 }
 
 // Assemble the density sub2d array in each process into a global one, which is straightforwardly transferred by
 // the adios2 API from coupler to Part3.
 void DatasProc3D::oldAssemDensiSendtoPart3(BoundaryDescr3D& bdesc)
 {
+  PERFSTUBS_START_STRING(__func__);
   zDensityBoundaryBufAssign(densin,bdesc);
   InterpoDensity3D(bdesc);
   CmplxdataToRealdata3D();
@@ -451,12 +468,14 @@ void DatasProc3D::oldAssemDensiSendtoPart3(BoundaryDescr3D& bdesc)
   free(recvcount);
   free(rdispls);
   free(blocktmp);
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 // Assemble the density sub2d array in each process into a global one, which is straightforwardly transferred by
 // the adios2 API from coupler to Part3.
 void DatasProc3D::AssemDensiSendtoPart3(BoundaryDescr3D& bdesc)
 {
+  PERFSTUBS_START_STRING(__func__);
   double*** tmpmat = new double**[p3->li0];
     for(LO i=0;i<p3->li0;i++){
       tmpmat[i]=new double*[p3->lj0];
@@ -601,11 +620,13 @@ void DatasProc3D::AssemDensiSendtoPart3(BoundaryDescr3D& bdesc)
   }
   free(tmpmat);
   tmpmat=NULL;
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 //I dont's understand the function of the following matrix.
 void DatasProc3D::oldInitmattoplane()
 {
+  PERFSTUBS_START_STRING(__func__);
   double y_cut;
   LO tmp_ind;
   LO ind_l_tmp;
@@ -625,11 +646,13 @@ void DatasProc3D::oldInitmattoplane()
       }
     }
   }
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 
 void DatasProc3D::Initmattoplane()
 {
+  PERFSTUBS_START_STRING(__func__);
   for(LO i=0;i<p3->li0;i++){
     for(LO o=0;o<p1->n_cuts;o++){
       for(LO j=0;j<p1->lj0;j++){
@@ -661,12 +684,14 @@ void DatasProc3D::Initmattoplane()
   std::cout<<"sum of mat_to_plane, mype_x="<<p1->mype_x<<" "<<sum<<'\n';
 }
 
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 
 //The function of this routines is not clear so far.
 void DatasProc3D::DensityToPart3()
 {
+  PERFSTUBS_START_STRING(__func__);
   for(LO i=0;i<p3->li0;i++){
     for(LO k=0;k<p3->mylk0[i];k++){
       for(LO j=0;j<p3->lj0;j++){
@@ -678,11 +703,13 @@ void DatasProc3D::DensityToPart3()
       }
     }
   }
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 // not very clear about the function of this routine
 void DatasProc3D::Prepare_mats_from_planes()
 {
+  PERFSTUBS_START_STRING(__func__);
   double dphi=2.0*cplPI/double(p1->n0_global*p1->n_cuts);
   double* phi_l=new double[p1->n_cuts];
   for(int i=0;i<p1->n_cuts;i++){
@@ -841,10 +868,12 @@ void DatasProc3D::Prepare_mats_from_planes()
 
   }
   
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 void DatasProc3D::TestInitPotentAlongz(const Part3Mesh3D* p3m3d,const LO npy, const LO n) 
 {
+  PERFSTUBS_START_STRING(__func__);
   if(npy==1){
     LO li0,lj0,lk0;
     li0=p3->li0;
@@ -867,10 +896,12 @@ void DatasProc3D::TestInitPotentAlongz(const Part3Mesh3D* p3m3d,const LO npy, co
       }
     }
   }
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 DatasProc3D::~DatasProc3D()
 {
+  PERFSTUBS_START_STRING(__func__);
   FreeFourierPlan3D();
   if(densrecv!=NULL){
     for(LO i=0;i<p1->li0;i++){
@@ -887,6 +918,7 @@ DatasProc3D::~DatasProc3D()
   if(potentouttmp!=NULL) delete[] potentouttmp;
   if(potentinterpo!=NULL) delete[] potentinterpo;
   if(potentpart1!=NULL) delete[] potentpart1;       
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 

--- a/src/fourierdataproc.cc
+++ b/src/fourierdataproc.cc
@@ -11,6 +11,7 @@ namespace coupler {
 // Beforing invoking this routine, the FFtw plan routine must be invoked. 
 void DatasProc3D::CmplxdataToRealdata3D()
 {
+  PERFSTUBS_START_STRING(__func__);
   if(densintmp==NULL){
     std::cout<<"ERROR: before invoking CmplxdataToRealdata3D, DatasProc3.densintmp must be allocated"<<'\n';
     std::exit(EXIT_FAILURE);
@@ -31,10 +32,12 @@ void DatasProc3D::CmplxdataToRealdata3D()
       }
     }
   }
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 void DatasProc3D::RealdataToCmplxdata3D()
 {
+  PERFSTUBS_START_STRING(__func__);
   if(potentintmp==NULL){
     std::cout<<"ERROR: before invoking CmplxdataToRealdata3, DatasProc3D.potentintmp must be allocated"<<'\n';
     std::exit(EXIT_FAILURE);
@@ -56,6 +59,7 @@ void DatasProc3D::RealdataToCmplxdata3D()
       }
     }
   }
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 //TODO Incomplete, Not used, put into the class it supports, I assume DatasProc3D
@@ -64,6 +68,7 @@ void DatasProc3D::RealdataToCmplxdata3D()
 void TransposeComplex(CV** InMatrix,CV** OutMatrix, DatasProc3D& dp3d,
      Part1ParalPar3D& p1pp3d)
 {
+  PERFSTUBS_START_STRING(__func__);
   LO ny0 = dp3d.getP1ny0();
   LO npy = dp3d.getP1npy();
 
@@ -79,10 +84,12 @@ void TransposeComplex(CV** InMatrix,CV** OutMatrix, DatasProc3D& dp3d,
       rbuf[i][j]=new CV[npy];
     }
   }
+  PERFSTUBS_STOP_STRING(__func__);
 }
 // It's not finished for yparal==true here.
 void DatasProc3D::ExecuteCmplxToReal()
 {
+  PERFSTUBS_START_STRING(__func__);
    if(yparal==true){
      CV** tmp_cmplx;
      tmp_cmplx=new CV*[p1->ny0];
@@ -97,30 +104,35 @@ void DatasProc3D::ExecuteCmplxToReal()
     }else{
      fftw_execute(plan_backward);
     } 
+  PERFSTUBS_STOP_STRING(__func__);
  }
 
 void DatasProc3D::ExecuteRealToCmplx()
 {
+   PERFSTUBS_START_STRING(__func__);
    if(yparal==true){
      // Here is not finished for yparal=true
    } else{
      fftw_execute(plan_forward);
    }
-
+  PERFSTUBS_STOP_STRING(__func__);
  } 
 
 void DatasProc3D::InitFourierPlan3D()
 { 
+  PERFSTUBS_START_STRING(__func__);
   if(yparal==false){
     plan_backward=fftw_plan_dft_c2r_1d(p1->lj0*2,
                        reinterpret_cast<fftw_complex*>(densintmp),densouttmp,FFTW_ESTIMATE); 
     plan_forward=fftw_plan_dft_r2c_1d(p1->y_res_back,potentintmp,
                       reinterpret_cast<fftw_complex*>(potentouttmp),FFTW_ESTIMATE);
   }
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 void DatasProc3D::FreeFourierPlan3D()
 {
+  PERFSTUBS_START_STRING(__func__);
   if(plan_forward)
     fftw_destroy_plan(plan_forward);
   if(plan_backward)
@@ -135,6 +147,7 @@ void DatasProc3D::FreeFourierPlan3D()
   delete[] dp3d.potentouttmp;
   dp3d.potentouttmp=NULL;
 */
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 }  

--- a/src/importpart3mesh.cc
+++ b/src/importpart3mesh.cc
@@ -111,7 +111,6 @@ void Part3Mesh3D::init(const Part1ParalPar3D &p1pp3d,
      DistriPart3zcoords(p1pp3d, test_dir);
 
 // for debugging
-     MPI_Barrier(MPI_COMM_WORLD);
      bool debug = false;
      if(debug){
        for(LO i=0;i<li0;i++){

--- a/src/importpart3mesh.cc
+++ b/src/importpart3mesh.cc
@@ -10,6 +10,7 @@ namespace coupler{
 void Part3Mesh3D::init(const Part1ParalPar3D &p1pp3d,
     const std::string test_dir)
 {
+   PERFSTUBS_START_STRING(__func__);
    nstart = new LO[p1pp3d.nx0];
    LO numsurf;
    int root=0;
@@ -126,10 +127,12 @@ void Part3Mesh3D::init(const Part1ParalPar3D &p1pp3d,
       }
     } 
   }
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 void Part3Mesh3D::BlockIndexes(const MPI_Comm comm_x,const LO mype_x,const LO npx)
 {
+  PERFSTUBS_START_STRING(__func__);
   GO* inds = new GO[npx]; 
   blockcount=0;
   for(LO i=0;i<li0;i++)
@@ -143,11 +146,13 @@ void Part3Mesh3D::BlockIndexes(const MPI_Comm comm_x,const LO mype_x,const LO np
      blockstart+=inds[i];
   blockend=blockstart+blockcount-1;
   delete[] inds;
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 
 void InitzcoordsInCoupler(double* zcoords,LO* versurf,LO nsurf)
 {
+  PERFSTUBS_START_STRING(__func__);
   double shift=0.1;
   GO num=0;
   for(LO i=0;i<nsurf;i++){
@@ -157,12 +162,14 @@ void InitzcoordsInCoupler(double* zcoords,LO* versurf,LO nsurf)
       num++;
     }
   } 
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 //when prepro=ture
 void Part3Mesh3D::DistriPart3zcoords(const Part1ParalPar3D &p1pp3d,
     const std::string test_dir)
 {
+  PERFSTUBS_START_STRING(__func__);
   if(preproc==true){
     if(test_case==TestCase::t0){
       zcoordall = new double[activenodes];
@@ -216,10 +223,12 @@ void Part3Mesh3D::DistriPart3zcoords(const Part1ParalPar3D &p1pp3d,
       numsurf+=1;        
     }
   }  
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 void Part3Mesh3D::JugeFirstSurfaceMatch(double xp1)
 {
+  PERFSTUBS_START_STRING(__func__);
   double* tmp = new double[nsurf];
   for(LO i=0;i<nsurf; i++){
     tmp[i]=abs(xcoords[i]-(xp1));
@@ -234,16 +243,19 @@ void Part3Mesh3D::JugeFirstSurfaceMatch(double xp1)
     exit(1);
   }
   delete[] tmp;
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 LO  minloc(const double* array, const LO n)
 {
+    PERFSTUBS_START_STRING(__func__);
     double zmin=minimalvalue(array, n);
     LO num=0;
     for(LO i=0;i<n;i++){ 
       num=i;
       if(array[i]==zmin) break;
     }
+    PERFSTUBS_STOP_STRING(__func__);
     return num;
  }
 
@@ -252,6 +264,7 @@ LO  minloc(const double* array, const LO n)
 void Part3Mesh3D::DistributePoints(const double* exterarr, const LO gstart,LO li, 
                   const double* interarr, const Part1ParalPar3D  &p1pp3d)
 {
+  PERFSTUBS_START_STRING(__func__);
   if(preproc==true){
     LO nstart;
     double* tmp=new double[versurf[li]];
@@ -295,16 +308,19 @@ void Part3Mesh3D::DistributePoints(const double* exterarr, const LO gstart,LO li
       <<" "<<mylk2[li-gstart]<<" "<<'\n'; 
     }
   }
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
  double minimalvalue(const double* array, const LO n)
 {
+    PERFSTUBS_START_STRING(__func__);
     double tmp=array[0];
     for(LO i=1;i<n;i++){
       if(tmp>array[i]){
         tmp=array[i];
       }
     }
+    PERFSTUBS_STOP_STRING(__func__);
     return tmp;      
 }
 

--- a/src/interpo.cc
+++ b/src/interpo.cc
@@ -10,6 +10,7 @@ namespace coupler {
 template<class T>
 T Lag3dInterpo1D(const T yin[4],const double xin[4],const double x)
 {
+  PERFSTUBS_START_STRING(__func__);
   double l0,l1,l2,l3;
   T yout;
   l0=(x-xin[1])*(x-xin[2])*(x-xin[3])/(xin[0]-xin[1])/(xin[0]-xin[2])/(xin[0]-xin[3]);
@@ -17,12 +18,14 @@ T Lag3dInterpo1D(const T yin[4],const double xin[4],const double x)
   l2=(x-xin[0])*(x-xin[1])*(x-xin[3])/(xin[2]-xin[0])/(xin[2]-xin[1])/(xin[2]-xin[3]);
   l3=(x-xin[0])*(x-xin[1])*(x-xin[2])/(xin[3]-xin[0])/(xin[3]-xin[1])/(xin[3]-xin[2]);
   yout=yin[0]*l0+yin[1]*l1+yin[2]*l2+yin[3]*l3;
+  PERFSTUBS_STOP_STRING(__func__);
   return yout;
 }
 
 //central 3rd order Lagrange polynormal interpolation
 template<class T>
 void Lag3dArray(const T* yin,const double* xin,const LO nin,T* yout,const double* xout,const LO nout){
+  PERFSTUBS_START_STRING(__func__);
   LO jstart=2;
   LO j1=jstart;
   LO j2,j0,jm;
@@ -48,10 +51,12 @@ void Lag3dArray(const T* yin,const double* xin,const LO nin,T* yout,const double
     func[3]=yin[j2];
     yout[j]=Lag3dInterpo1D(func,coords,x);
   }
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 void DatasProc3D::InterpoDensity3D(const BoundaryDescr3D &bdesc)
 {
+  PERFSTUBS_START_STRING(__func__);
   CV* yin;
   double* xin;
   CV* yout;
@@ -100,11 +105,13 @@ void DatasProc3D::InterpoDensity3D(const BoundaryDescr3D &bdesc)
   delete[] xin,yin;
   xin=NULL;
   yin=NULL;
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 
 void DatasProc3D::InterpoPotential3D(const BoundaryDescr3D &bdesc)
 {
+  PERFSTUBS_START_STRING(__func__);
   CV* yin;
   CV* yout;
   double* xin;
@@ -136,7 +143,7 @@ void DatasProc3D::InterpoPotential3D(const BoundaryDescr3D &bdesc)
      delete[] yin; 
     }
   }
-
+  PERFSTUBS_STOP_STRING(__func__);
 }
 
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,9 @@ target_link_libraries(test_init coupler)
 add_executable(cpl cpl.cc)
 target_link_libraries(cpl coupler)
 
+link_directories(..${CMAKE_BINARY_DIR}/perfstubs/perfstubs)
+target_link_libraries(coupler perfstubs)
+
 set(drivers passthrough test_init cpl)
 install(TARGETS ${drivers})
 

--- a/test/cpl.cc
+++ b/test/cpl.cc
@@ -94,7 +94,6 @@ int main(int argc, char **argv){
   mesh3=&p3m3d;
   coupler::DatasProc3D dp3d(mesh1, mesh3, preproc, test_case, ypar, nummode);
   if(!p1pp3d.mype)std::cerr << "0.9"<< "\n";
-  MPI_Barrier(MPI_COMM_WORLD);
   coupler::destroy(q_prof);
   coupler::destroy(gene_xval);
   coupler::destroy(gene_parpar);
@@ -117,11 +116,9 @@ int main(int argc, char **argv){
       std::cout<<"mype, start count"<<p1pp3d.mype<<" "<<start[0]<<" "<<start[1]<<" "<<count[0]<<" "<<count[1]<<'\n';
       m=i*RK_count+j;
       coupler::Array2d<coupler::CV>* densityfromGENE = coupler::receive_density(dir, gDens,start,count,MPI_COMM_WORLD,m);
-      MPI_Barrier(MPI_COMM_WORLD);
 
       dp3d.DistriDensiRecvfromPart1(densityfromGENE);
       cplxsum=coupler::CV(0.0,0.0);
-      MPI_Barrier(MPI_COMM_WORLD);
       coupler::printSumm3D(dp3d.densin,p1pp3d.li0,p1pp3d.lj0,inds3d,cplxsum,
       MPI_COMM_WORLD,"densityfromGENE",m);
 
@@ -136,7 +133,6 @@ int main(int argc, char **argv){
       }
       realsum=0.0;
       coupler::GO INDS1d[2]={0,p3m3d.lj0*p3m3d.blockcount};
-      MPI_Barrier(MPI_COMM_WORLD);
       std::cout<<"p3m3d.lj0*p3m3d.blockcount="<<p3m3d.lj0*p3m3d.blockcount<<'\n';
       //coupler::printSumm1D(dp3d.denssend,INDS1d,realsum,p1pp3d.comm_x,"densitytoXGC",m);
 

--- a/test/cpl.cc
+++ b/test/cpl.cc
@@ -8,7 +8,7 @@
 #include <string>
 #include <fstream> 
 #define PERFSTUBS_USE_TIMERS
-#include "../perfstubs/perfstubs_api/timer.h"
+#include "perfstubs_api/timer.h"
 
 void exParFor() {
   Kokkos::parallel_for(

--- a/test/cpl.cc
+++ b/test/cpl.cc
@@ -1,3 +1,4 @@
+#include "../perfstubs/perfstubs_api/timer.h"
 #include "adios2Routines.h"
 #include "couplingTypes.h"
 #include "dataprocess.h"
@@ -105,7 +106,7 @@ int main(int argc, char **argv){
   coupler::LO* inds3d=new coupler::LO[p1pp3d.li0];
   for(coupler::LO h=0;h<p1pp3d.li0;h++) inds3d[h]=p1pp3d.lk0;
  
-  for (int i = 0; i < 30; i++) {
+  for (int i = 0; i < time_step; i++) {
     for (int j = 0; j < RK_count; j++) {
       coupler::GO start[2]={0, p1pp3d.blockstart};
       coupler::GO count[2]={coupler::GO(p1pp3d.lj0), p1pp3d.blockcount};
@@ -133,7 +134,7 @@ int main(int argc, char **argv){
       coupler::GO INDS1d[2]={0,p3m3d.lj0*p3m3d.blockcount};
       MPI_Barrier(MPI_COMM_WORLD);
       std::cout<<"p3m3d.lj0*p3m3d.blockcount="<<p3m3d.lj0*p3m3d.blockcount<<'\n';
-      coupler::printSumm1D(dp3d.denssend,INDS1d,realsum,p1pp3d.comm_x,"densitytoXGC",m);
+      //coupler::printSumm1D(dp3d.denssend,INDS1d,realsum,p1pp3d.comm_x,"densitytoXGC",m);
 
       if(!debug){
         coupler::send_from_coupler(adios,dir,densitytoXGC,cDens.IO,cDens.eng,cDens.name,senddensity,MPI_COMM_WORLD,m);    


### PR DESCRIPTION
`MPI_Barrier` s within the coupler accounted for the a large portion of the timing as shown by the `tau+perfstub` output below
I removed all explicit calls to `MPI_Barrier` within the coupler

![n0_t0_stat_table](https://user-images.githubusercontent.com/46372584/91074080-11becd80-e60a-11ea-93dc-854e5fabe884.jpg)
