### PR TITLE
Clean up CUDA build warnings related to unused functions/variables

### DIFF
--- a/src/pcms/interpolator/mls_interpolation.cpp
+++ b/src/pcms/interpolator/mls_interpolation.cpp
@@ -205,15 +205,6 @@ int calculate_scratch_shared_size(const SupportResults& support,
       int end_ptr = support.supports_ptr[i + 1];
       int nsupports = end_ptr - start_ptr;
 
-      int max_size;
-      int min_size;
-      if (nsupports > basis_size) {
-        max_size = nsupports;
-        min_size = basis_size;
-      } else {
-        max_size = basis_size;
-        min_size = nsupports;
-      }
       size_t total_shared_size = 0;
       total_shared_size +=
         ScratchMatView::shmem_size(basis_size, basis_size); // Vt

--- a/src/pcms/interpolator/mls_interpolation_impl.hpp
+++ b/src/pcms/interpolator/mls_interpolation_impl.hpp
@@ -170,8 +170,6 @@ void normalize_supports(const member_type& team, double* target_point,
   int dim = support_coordinates.extent(1);
 
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nsupports), [=](int i) {
-    Real pivot_point[MAX_DIM];
-
     for (int j = 0; j < dim; ++j) {
       support_coordinates(i, j) -= target_point[j];
     }


### PR DESCRIPTION
Problem: Building with CUDA generates several warnings about functions and variables that were declared but never referenced. For example,
```
/temp/pcms/test/xgc_n0_coupling_server.cpp(81): warning #177-D: function "AverageAndSetFields" was declared but never referenced
  static void AverageAndSetFields(const std::vector<pcms::CoupledField*> & from_fields,
              ^

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"

temp/pcms/src/pcms/interpolator/mls_interpolation_impl.hpp(173): warning #177-D: variable "pivot_point" was declared but never referenced
      Real pivot_point[MAX_DIM];
           ^

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"
```
Solution: I've identified and removed what appears to be deprecated code, but please verify that: 

- [ ] The warnings are not caused by my misconfiguration.
- [ ] None of the removed code is actually needed for ongoing development.
- [ ] I haven't missed any legitimate use cases for the removed functions/variables

If any of the removed code should be retained, please let me know.