### PR TITLE
Downgrade ADIOS2 to `v2.10.2` in ci

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -136,7 +136,7 @@ jobs:
       with:
         repo-name: 'ADIOS2-openmpi'
         repo-path: 'ornladios/ADIOS2'
-        repo-ref: ''
+        repo-ref: 'v2.10.2'
         cache: true
         options: '-DADIOS2_USE_CUDA=OFF'
 

--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -136,7 +136,7 @@ jobs:
       with:
         repo-name: 'ADIOS2'
         repo-path: 'ornladios/ADIOS2'
-        repo-ref: ''
+        repo-ref: 'v2.10.2'
         cache: true
         options: '-DADIOS2_USE_CUDA=OFF'
 


### PR DESCRIPTION
Avoid using the latest pre-release ADIOS2 to address issue #215 .