### PR TITLE
Specify redev to latest commit

### DIFF
--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -145,7 +145,7 @@ jobs:
       with:
         repo-name: 'redev'
         repo-path: 'SCOREC/redev'
-        repo-ref: 'v4.3.1'
+        repo-ref: '1452ec290dc6f8638019e342758325611e16ad77'
         cache: true
         options: '-DCMAKE_CXX_COMPILER=`which mpicxx`
                   -DMPIEXEC_EXECUTABLE=`which mpirun`


### PR DESCRIPTION
Pin redev to latest commit to include the exported perfstub and solve error like [here](https://github.com/SCOREC/pcms/actions/runs/20037113227/job/57461439314?pr=229). 