### PR TITLE
Use target coordinates in `interpolate_field2`

### DIFF
--- a/src/pcms/transfer_field2.h
+++ b/src/pcms/transfer_field2.h
@@ -33,7 +33,7 @@ void interpolate_field2(const FieldT<T>& source, FieldT<T>& target)
     throw std::runtime_error("Coordinate system mismatch");
   }
 
-  auto coords = source.GetLayout().GetDOFHolderCoordinates();
+  auto coords = target.GetLayout().GetDOFHolderCoordinates();
   std::vector<Real> evaluation(coords.GetCoordinates().size() / 2);
   FieldDataView<Real, HostMemorySpace> data_view{make_array_view(evaluation),
                                                  source.GetCoordinateSystem()};


### PR DESCRIPTION
Field transfer should evaluate the target coordinates in the source field.