### PR TITLE
Mirror source tree for adapter headers

### DIFF
--- a/examples/external-usage-example/main.cpp
+++ b/examples/external-usage-example/main.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <pcms/utility/print.h>
+#include <pcms/create_field.h>
 
 int main()
 {

--- a/examples/external-usage-example/main.cpp
+++ b/examples/external-usage-example/main.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <pcms/utility/print.h>
 #include <pcms/create_field.h>
-
+#include <pcms/capi/interpolator.h>
 int main()
 {
   std::cout << "Testing PCMS dependency export..." << std::endl;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ set(
   pcms/field_communicator.h
   pcms/field_communicator2.h
   pcms/field_evaluation_methods.h
+  pcms/field_layout_communicator.h
   pcms/partition.h
   pcms/coupler.h
   pcms/coordinate_system.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,10 +59,12 @@ if(PCMS_ENABLE_OMEGA_H)
     pcms/transfer_field2.h
     pcms/uniform_grid.h
     pcms/point_search.h
+  )
+  list(APPEND ADAPTER_HEADERS
+    pcms/adapter/omega_h/omega_h_field.h
     pcms/adapter/uniform_grid/uniform_grid_field_layout.h
     pcms/adapter/uniform_grid/uniform_grid_field.h
   )
-  list(APPEND ADAPTER_HEADERS pcms/adapter/omega_h/omega_h_field.h)
 endif()
 
 find_package(Kokkos REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,8 +104,7 @@ target_sources(pcms_core PUBLIC
         FILE_SET adapters
         TYPE HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/pcms
-        FILES ${ADAPTER_HEADERS}
-)
+        FILES ${ADAPTER_HEADERS})
 install(
   TARGETS pcms_core
   EXPORT pcms_core-targets

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+
+
 # TODO split out the field transfer library
 set(
   PCMS_HEADERS
@@ -15,46 +17,42 @@ set(
   pcms/coupler.h
   pcms/coordinate_system.h
   pcms/field_layout.h
-  pcms/adapter/point_cloud/point_cloud_layout.h
-  pcms/adapter/point_cloud/point_cloud.h
-  pcms/adapter/omega_h/omega_h_field_layout.h
-  pcms/adapter/omega_h/omega_h_field2.h
 )
 
 set(
   PCMS_SOURCES
   pcms.cpp
   pcms/create_field.cpp
-  pcms/adapter/xgc/xgc_field_adapter.h
   pcms/adapter/point_cloud/point_cloud_layout.cpp
   pcms/adapter/point_cloud/point_cloud.cpp
   pcms/adapter/omega_h/omega_h_field_layout.cpp
   pcms/adapter/omega_h/omega_h_field2.cpp
-  pcms/adapter/xgc/xgc_field_adapter.h
 )
-
+set(
+  ADAPTER_HEADERS
+  ${CMAKE_SOURCE_DIR}/src/pcms/adapter/point_cloud
+)
 configure_file(pcms/version.h.in pcms/version.h)
 configure_file(pcms/configuration.h.in pcms/configuration.h)
 list(APPEND PCMS_HEADERS ${CMAKE_CURRENT_BINARY_DIR}/pcms/version.h ${CMAKE_CURRENT_BINARY_DIR}/pcms/configuration.h)
 
 add_subdirectory(pcms/utility)
 
-
 if(PCMS_ENABLE_XGC)
   list(APPEND PCMS_SOURCES pcms/adapter/xgc/xgc_reverse_classification.cpp)
-  list(APPEND PCMS_HEADERS pcms/adapter/xgc/xgc_reverse_classification.h)
+  list(APPEND ADAPTER_HEADERS ${CMAKE_SOURCE_DIR}/src/pcms/adapter/xgc)
 endif()
 if(PCMS_ENABLE_OMEGA_H)
   list(APPEND PCMS_SOURCES pcms/point_search.cpp)
   list(
     APPEND
     PCMS_HEADERS
-    pcms/adapter/omega_h/omega_h_field.h
     pcms/transfer_field.h
     pcms/transfer_field2.h
     pcms/uniform_grid.h
     pcms/point_search.h
   )
+  list(APPEND ADAPTER_HEADERS ${CMAKE_SOURCE_DIR}/src/pcms/adapter/omega_h)
 endif()
 
 find_package(Kokkos REQUIRED)
@@ -147,6 +145,14 @@ install(
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pcms
 )
+
+# Mirror the src tree for adapter headers
+foreach(hdr IN LISTS ADAPTER_HEADERS)
+  install(DIRECTORY ${hdr}
+          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pcms/adapter
+          FILES_MATCHING PATTERN "*.h")
+endforeach ()
+
 # install external headers
 install(
   DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/pcms/external/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,3 @@
-
-
 # TODO split out the field transfer library
 set(
   PCMS_HEADERS
@@ -30,8 +28,13 @@ set(
 )
 set(
   ADAPTER_HEADERS
-  ${CMAKE_SOURCE_DIR}/src/pcms/adapter/point_cloud
+  pcms/adapter/point_cloud/point_cloud_layout.h
+  pcms/adapter/point_cloud/point_cloud.h
+  pcms/adapter/omega_h/omega_h_field_layout.h
+  pcms/adapter/omega_h/omega_h_field2.h
+  pcms/adapter/xgc/xgc_field_adapter.h
 )
+
 configure_file(pcms/version.h.in pcms/version.h)
 configure_file(pcms/configuration.h.in pcms/configuration.h)
 list(APPEND PCMS_HEADERS ${CMAKE_CURRENT_BINARY_DIR}/pcms/version.h ${CMAKE_CURRENT_BINARY_DIR}/pcms/configuration.h)
@@ -40,7 +43,7 @@ add_subdirectory(pcms/utility)
 
 if(PCMS_ENABLE_XGC)
   list(APPEND PCMS_SOURCES pcms/adapter/xgc/xgc_reverse_classification.cpp)
-  list(APPEND ADAPTER_HEADERS ${CMAKE_SOURCE_DIR}/src/pcms/adapter/xgc)
+  list(APPEND ADAPTER_HEADERS pcms/adapter/xgc/xgc_reverse_classification.h)
 endif()
 if(PCMS_ENABLE_OMEGA_H)
   list(APPEND PCMS_SOURCES pcms/point_search.cpp)
@@ -52,7 +55,7 @@ if(PCMS_ENABLE_OMEGA_H)
     pcms/uniform_grid.h
     pcms/point_search.h
   )
-  list(APPEND ADAPTER_HEADERS ${CMAKE_SOURCE_DIR}/src/pcms/adapter/omega_h)
+  list(APPEND ADAPTER_HEADERS pcms/adapter/omega_h/omega_h_field.h)
 endif()
 
 find_package(Kokkos REQUIRED)
@@ -88,6 +91,12 @@ target_include_directories(
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
+target_sources(pcms_core PUBLIC
+        FILE_SET adapters
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/pcms
+        FILES ${ADAPTER_HEADERS}
+)
 install(
   TARGETS pcms_core
   EXPORT pcms_core-targets
@@ -97,6 +106,7 @@ install(
   INCLUDES
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pcms
+  FILE_SET adapters DESTINATION  ${CMAKE_INSTALL_INCLUDEDIR}/pcms
 )
 
 configure_package_config_file(
@@ -144,14 +154,9 @@ install(
   INCLUDES
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pcms
+  FILE_SET adapters DESTINATION  ${CMAKE_INSTALL_INCLUDEDIR}/pcms
 )
 
-# Mirror the src tree for adapter headers
-foreach(hdr IN LISTS ADAPTER_HEADERS)
-  install(DIRECTORY ${hdr}
-          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pcms/adapter
-          FILES_MATCHING PATTERN "*.h")
-endforeach ()
 
 # install external headers
 install(

--- a/src/pcms/capi/CMakeLists.txt
+++ b/src/pcms/capi/CMakeLists.txt
@@ -18,13 +18,17 @@ set(CAPI_CORE_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/client.h
 set_target_properties(
   pcms_capi_core PROPERTIES PUBLIC_HEADER "${CAPI_CORE_HEADERS}" OUTPUT_NAME pcmscapicore
              EXPORT_NAME capi::core)
-
+target_sources(pcms_capi_core PUBLIC
+        FILE_SET core
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        FILES ${CAPI_CORE_HEADERS})
 add_library(pcms_capi_interpolator mesh.cpp interpolator.cpp kokkos.cpp)
 add_library(pcms::capi::interpolator ALIAS pcms_capi_interpolator)
 target_link_libraries(pcms_capi_interpolator PUBLIC MPI::MPI_C PRIVATE pcms::interpolator)
 target_include_directories(pcms_capi_interpolator
         PUBLIC
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>" # this makes the module path cpms/capi
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>" # this makes the module path pcms/capi
         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/pcms/capi>")
 set(CAPI_INTERPOLATOR_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/interpolator.h
                      ${CMAKE_CURRENT_SOURCE_DIR}/mesh.h)
@@ -32,7 +36,11 @@ set_target_properties(pcms_capi_interpolator
   PROPERTIES PUBLIC_HEADERS "${CAPI_INTERPOLATOR_HEADERS}"
              OUTPUT_NAME pcmscapiinterpolator
              EXPORT_NAME capi::interpolator)
-
+target_sources(pcms_capi_interpolator PUBLIC
+        FILE_SET interpolator
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        FILES ${CAPI_INTERPOLATOR_HEADERS})
 # high level interface target
 add_library(pcms_capi INTERFACE)
 add_library(pcms::capi ALIAS pcms_capi)
@@ -63,7 +71,7 @@ install(
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   INCLUDES
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pcms/capi/)
+  FILE_SET core DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pcms)
 install(
   EXPORT pcms_capi_core-targets
   NAMESPACE pcms::
@@ -77,7 +85,7 @@ install(
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   INCLUDES
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pcms/capi/)
+  FILE_SET interpolator DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pcms)
 install(
   EXPORT pcms_capi_interpolator-targets
   NAMESPACE pcms::

--- a/src/pcms/capi/CMakeLists.txt
+++ b/src/pcms/capi/CMakeLists.txt
@@ -21,7 +21,7 @@ set_target_properties(
 target_sources(pcms_capi_core PUBLIC
         FILE_SET core
         TYPE HEADERS
-        BASE_DIRS ${PROJECT_SOURCE_DIR}/src/pcms
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/..
         FILES ${CAPI_CORE_HEADERS})
 add_library(pcms_capi_interpolator mesh.cpp interpolator.cpp kokkos.cpp)
 add_library(pcms::capi::interpolator ALIAS pcms_capi_interpolator)
@@ -40,7 +40,7 @@ set_target_properties(pcms_capi_interpolator
 target_sources(pcms_capi_interpolator PUBLIC
         FILE_SET interpolator
         TYPE HEADERS
-        BASE_DIRS ${PROJECT_SOURCE_DIR}/src/pcms
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/..
         FILES ${CAPI_INTERPOLATOR_HEADERS})
 # high level interface target
 add_library(pcms_capi INTERFACE)

--- a/src/pcms/capi/CMakeLists.txt
+++ b/src/pcms/capi/CMakeLists.txt
@@ -16,12 +16,12 @@ target_include_directories(
 set(CAPI_CORE_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/client.h
                  ${CMAKE_CURRENT_SOURCE_DIR}/kokkos.h)
 set_target_properties(
-  pcms_capi_core PROPERTIES PUBLIC_HEADER "${CAPI_CORE_HEADERS}" OUTPUT_NAME pcmscapicore
+  pcms_capi_core PROPERTIES OUTPUT_NAME pcmscapicore
              EXPORT_NAME capi::core)
 target_sources(pcms_capi_core PUBLIC
         FILE_SET core
         TYPE HEADERS
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        BASE_DIRS ${PROJECT_SOURCE_DIR}/src/pcms
         FILES ${CAPI_CORE_HEADERS})
 add_library(pcms_capi_interpolator mesh.cpp interpolator.cpp kokkos.cpp)
 add_library(pcms::capi::interpolator ALIAS pcms_capi_interpolator)
@@ -30,16 +30,17 @@ target_include_directories(pcms_capi_interpolator
         PUBLIC
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>" # this makes the module path pcms/capi
         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/pcms/capi>")
+
 set(CAPI_INTERPOLATOR_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/interpolator.h
                      ${CMAKE_CURRENT_SOURCE_DIR}/mesh.h)
+
 set_target_properties(pcms_capi_interpolator
-  PROPERTIES PUBLIC_HEADERS "${CAPI_INTERPOLATOR_HEADERS}"
-             OUTPUT_NAME pcmscapiinterpolator
+  PROPERTIES OUTPUT_NAME pcmscapiinterpolator
              EXPORT_NAME capi::interpolator)
 target_sources(pcms_capi_interpolator PUBLIC
         FILE_SET interpolator
         TYPE HEADERS
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        BASE_DIRS ${PROJECT_SOURCE_DIR}/src/pcms
         FILES ${CAPI_INTERPOLATOR_HEADERS})
 # high level interface target
 add_library(pcms_capi INTERFACE)

--- a/src/pcms/interpolator/CMakeLists.txt
+++ b/src/pcms/interpolator/CMakeLists.txt
@@ -16,15 +16,18 @@ set(PCMS_FIELD_TRANSFER_HEADERS
 
 set(PCMS_FIELD_TRANSFER_SOURCES
     mls_interpolation.cpp
-    interpolation_base.cpp)
-install(FILES ${PCMS_FIELD_TRANSFER_HEADERS}
-        DESTINATION include/pcms/interpolator)
-
+    interpolation_base.cpp
+)
 
 add_library(pcms_interpolator ${PCMS_FIELD_TRANSFER_SOURCES})
 set_target_properties(pcms_interpolator PROPERTIES
         OUTPUT_NAME pcmsinterpolator
         EXPORT_NAME interpolator)
+target_sources(pcms_interpolator PUBLIC
+        FILE_SET transformer
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/..
+        FILES ${PCMS_FIELD_TRANSFER_HEADERS})
 add_library(pcms::interpolator ALIAS pcms_interpolator)
 target_compile_features(pcms_interpolator PUBLIC cxx_std_17)
 
@@ -39,8 +42,8 @@ target_include_directories(pcms_interpolator INTERFACE
 install(
   TARGETS pcms_interpolator
   EXPORT pcms_interpolator-targets
-  INCLUDES
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pcms/interpolator
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pcms/interpolator
+  FILE_SET transformer DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pcms
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 

--- a/src/pcms/utility/CMakeLists.txt
+++ b/src/pcms/utility/CMakeLists.txt
@@ -39,8 +39,11 @@ if (PCMS_ENABLE_SPDLOG)
 endif ()
 
 ## export the library
-set_target_properties(pcms_utility PROPERTIES PUBLIC_HEADER "${PCMS_UTILITY_HEADERS}")
-
+target_sources(pcms_utility PUBLIC
+        FILE_SET utilities
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../
+        FILES ${PCMS_UTILITY_HEADERS})
 install(
         TARGETS pcms_utility
         EXPORT pcms_utility-targets
@@ -49,7 +52,7 @@ install(
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         INCLUDES
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pcms/utility
+        FILE_SET utilities DESTINATION  ${CMAKE_INSTALL_INCLUDEDIR}/pcms
 )
 
 install(


### PR DESCRIPTION
Install adapter headers via `DIRECTORY` install.

## Changes

* Defined `ADAPTER_HEADERS`.
* Installed headers from `ADAPTER_HEADERS` into their respective directories.
* Included `create_field.h` in examples for external-usage-example usage testing.