### PR TITLE
adding `global_id_name` to `create_field`

### DIFF
--- a/src/pcms/create_field.cpp
+++ b/src/pcms/create_field.cpp
@@ -9,7 +9,7 @@ namespace pcms
 
 std::unique_ptr<FieldLayout> CreateLagrangeLayout(
   Omega_h::Mesh& mesh, int order, int num_components,
-  CoordinateSystem coordinate_system)
+  CoordinateSystem coordinate_system, std::string global_id_name)
 {
 
   std::array<int, 4> nodes_per_dim;
@@ -21,7 +21,7 @@ std::unique_ptr<FieldLayout> CreateLagrangeLayout(
   }
 
   return std::make_unique<OmegaHFieldLayout>(mesh, nodes_per_dim,
-                                             num_components, coordinate_system);
+                                             num_components, coordinate_system, global_id_name);
 }
 
 } // namespace pcms

--- a/src/pcms/create_field.cpp
+++ b/src/pcms/create_field.cpp
@@ -14,8 +14,7 @@ namespace pcms
 
 std::unique_ptr<FieldLayout> CreateLagrangeLayout(
   Omega_h::Mesh& mesh, int order, int num_components,
-  CoordinateSystem coordinate_system,
-  std::string global_id_name)
+  CoordinateSystem coordinate_system, std::string global_id_name)
 {
 
   std::array<int, 4> nodes_per_dim;
@@ -26,8 +25,8 @@ std::unique_ptr<FieldLayout> CreateLagrangeLayout(
     default: throw std::runtime_error("Unimplemented order");
   }
 
-  return std::make_unique<OmegaHFieldLayout>(mesh, nodes_per_dim,
-                                             num_components, coordinate_system, global_id_name);
+  return std::make_unique<OmegaHFieldLayout>(
+    mesh, nodes_per_dim, num_components, coordinate_system, global_id_name);
 }
 
 template <>

--- a/src/pcms/create_field.cpp
+++ b/src/pcms/create_field.cpp
@@ -14,7 +14,8 @@ namespace pcms
 
 std::unique_ptr<FieldLayout> CreateLagrangeLayout(
   Omega_h::Mesh& mesh, int order, int num_components,
-  CoordinateSystem coordinate_system, std::string global_id_name)
+  CoordinateSystem coordinate_system,
+  std::string global_id_name)
 {
 
   std::array<int, 4> nodes_per_dim;

--- a/src/pcms/create_field.h
+++ b/src/pcms/create_field.h
@@ -19,8 +19,7 @@ namespace pcms
 {
 std::unique_ptr<FieldLayout> CreateLagrangeLayout(
   Omega_h::Mesh& mesh, int order, int num_components,
-  CoordinateSystem coordinate_system,
-  std::string global_id_name="global");
+  CoordinateSystem coordinate_system, std::string global_id_name = "global");
 
 /**
  * \brief Create a binary field on a uniform grid indicating inside/outside mesh

--- a/src/pcms/create_field.h
+++ b/src/pcms/create_field.h
@@ -19,7 +19,8 @@ namespace pcms
 {
 std::unique_ptr<FieldLayout> CreateLagrangeLayout(
   Omega_h::Mesh& mesh, int order, int num_components,
-  CoordinateSystem coordinate_system,);
+  CoordinateSystem coordinate_system,
+  std::string global_id_name="global");
 
 /**
  * \brief Create a binary field on a uniform grid indicating inside/outside mesh

--- a/src/pcms/create_field.h
+++ b/src/pcms/create_field.h
@@ -19,7 +19,7 @@ namespace pcms
 {
 std::unique_ptr<FieldLayout> CreateLagrangeLayout(
   Omega_h::Mesh& mesh, int order, int num_components,
-  CoordinateSystem coordinate_system);
+  CoordinateSystem coordinate_system,);
 
 /**
  * \brief Create a binary field on a uniform grid indicating inside/outside mesh

--- a/src/pcms/create_field.h
+++ b/src/pcms/create_field.h
@@ -13,7 +13,8 @@ namespace pcms
 {
 std::unique_ptr<FieldLayout> CreateLagrangeLayout(
   Omega_h::Mesh& mesh, int order, int num_components,
-  CoordinateSystem coordinate_system);
+  CoordinateSystem coordinate_system,
+  std::string global_id_name="global");
 } // namespace pcms
 
 #endif // CREATE_FIELD_H_


### PR DESCRIPTION
Currently [`create_field.h`](https://github.com/SCOREC/pcms/blob/4ee0a663ae00b7cce990b147a813739420e8b213/src/pcms/create_field.cpp#L10C1-L25C2) isn't transferring the global_id name required for [`Omega_h layout`](https://github.com/SCOREC/pcms/blob/4ee0a663ae00b7cce990b147a813739420e8b213/src/pcms/adapter/omega_h/omega_h_field_layout.h#L15C1-L21C1.).