### PR TITLE
Update python path handling

### DIFF
--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -254,8 +254,7 @@ jobs:
     - name: Run Python API tests
       if: matrix.python_api == 'ON'
       run: |
-        export PYTHONPATH=${{ runner.temp }}/build-pcms/install/lib:$PYTHONPATH
-        export LD_LIBRARY_PATH=${{ runner.temp }}/build-pcms/install/lib:$LD_LIBRARY_PATH
+        export PYTHONPATH=${{ runner.temp }}/build-pcms/install/lib/python3.12/site-packages:$PYTHONPATH
         cd ${{ github.workspace }}/src/pcms/pythonapi
         python3 test_file_io.py
         python3 test_omega_h_field.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["scikit-build-core", "pybind11"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "pcms"
+version = "0.3.0"
+
+[tool.scikit-build.cmake.define]
+PCMS_ENABLE_Python = true
+PCMS_ENABLE_SPDLOG = false

--- a/src/pcms/pythonapi/CMakeLists.txt
+++ b/src/pcms/pythonapi/CMakeLists.txt
@@ -22,10 +22,14 @@ target_link_libraries(pcms PRIVATE Kokkos::kokkos pybind11::module MPI::MPI_C pc
 # scikit-build-core will set this variable
 if(SKBUILD)
   set(PCMS_PYTHON_INSTALL_LOCATION "${SKBUILD_PLATLIB_DIR}")
-# this is useful for direct CMake installation into python.
-# This enables spack environment installation to directly load the PyOmega_h module
 else()
+  # this is useful for direct CMake installation into python.
+  # This enables spack environment installation to directly load the PyOmega_h module
   set(PCMS_PYTHON_INSTALL_LOCATION "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  # Ensure the extension can resolve pcms shared libraries from a standard
+  # prefix install layout (e.g. Spack), where the module lives under
+  # <prefix>/<libdir>/pythonX.Y/site-packages and core libs live in <libdir>.
+  set_target_properties(pcms PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../../../")
 endif()
 
 

--- a/src/pcms/pythonapi/CMakeLists.txt
+++ b/src/pcms/pythonapi/CMakeLists.txt
@@ -18,16 +18,24 @@ pybind11_add_module(pcms
 set_target_properties(pcms PROPERTIES CXX_STANDARD 17)
 target_link_libraries(pcms PRIVATE Kokkos::kokkos pybind11::module MPI::MPI_C pcms::core pcms::interpolator)
 
+# if we are building as a python package from the pyproject.toml
+# scikit-build-core will set this variable
+if(SKBUILD)
+  set(PCMS_PYTHON_INSTALL_LOCATION "${SKBUILD_PLATLIB_DIR}")
+# this is useful for direct CMake installation into python.
+# This enables spack environment installation to directly load the PyOmega_h module
+else()
+  set(PCMS_PYTHON_INSTALL_LOCATION "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+endif()
 
 
 install(
         TARGETS pcms
         EXPORT pcms_python-targets
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+	RUNTIME DESTINATION ${PCMS_PYTHON_INSTALL_LOCATION}
+	LIBRARY DESTINATION ${PCMS_PYTHON_INSTALL_LOCATION}
         PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pcms/pythonapi/)
+
 install(
         EXPORT pcms_python-targets
         NAMESPACE pcms::


### PR DESCRIPTION
This PR fixes two issues with the python installation:
1. a `pyproject.toml` file and associated changes to the installation path are added
2. rpath handling and installation location are fixed, so that when `pcms+python` is build in a spack environment, the python package can directly be imported and used.

fixes #276 