### PR TITLE
enable building without petsc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,12 +133,14 @@ find_package(Kokkos CONFIG 4.5 REQUIRED)
 option(PCMS_ENABLE_MESHFIELDS "Enable MeshFields support" ON)
 option(PCMS_ENABLE_PETSC "Enable PETSc support" ON)
 
-if (PCMS_ENABLE_MESHFIELDS)
+if(PCMS_ENABLE_MESHFIELDS)
   find_package(meshfields REQUIRED)
   message(STATUS "Found MeshFields: ${meshfields_DIR} (found version ${meshfields_VERSION})")
 endif()
 
-find_package(PETSc REQUIRED)
+if(PCMS_ENABLE_PETSC)
+  find_package(PETSc REQUIRED)
+endif()
 
 add_subdirectory(src)
 

--- a/src/pcms/configuration.h.in
+++ b/src/pcms/configuration.h.in
@@ -6,3 +6,5 @@
 #cmakedefine PCMS_ENABLE_PRINT
 #cmakedefine PCMS_ENABLE_SPDLOG
 #cmakedefine PCMS_ENABLE_Fortran
+#cmakedefine PCMS_ENABLE_MESHFIELDS
+#cmakedefine PCMS_ENABLE_PETSC

--- a/src/pcms/transfer/CMakeLists.txt
+++ b/src/pcms/transfer/CMakeLists.txt
@@ -13,27 +13,33 @@ set(PCMS_FIELD_TRANSFER_HEADERS
     interpolation_base.h
     interpolation_helpers.h
     spline_interpolator.hpp
-    calculate_load_vector.hpp
-    calculate_mass_matrix.hpp
-    conservative_projection_solver.hpp
-    coo_assembly_utils.hpp
     load_vector_integrator.hpp
     mass_matrix_integrator.hpp
     mesh_intersection.hpp
-    petsc_utils.hpp)
+)
 
 
 set(PCMS_FIELD_TRANSFER_SOURCES
     adj_search.cpp
-    calculate_load_vector.cpp
-    calculate_mass_matrix.cpp
-    conservative_projection_solver.cpp
-    petsc_utils.cpp
-    coo_assembly_utils.cpp
     load_vector_integrator.cpp
     mesh_intersection.cpp
     mls_interpolation.cpp
     interpolation_base.cpp)
+
+if(PCMS_ENABLE_PETSC)
+  list(APPEND PCMS_FIELD_TRANSFER_HEADERS
+      calculate_load_vector.hpp
+      calculate_mass_matrix.hpp
+      conservative_projection_solver.hpp
+      coo_assembly_utils.hpp
+      petsc_utils.hpp)
+  list(APPEND PCMS_FIELD_TRANSFER_SOURCES
+      calculate_load_vector.cpp
+      calculate_mass_matrix.cpp
+      conservative_projection_solver.cpp
+      petsc_utils.cpp
+      coo_assembly_utils.cpp)
+endif()
 
 add_library(pcms_transfer ${PCMS_FIELD_TRANSFER_SOURCES})
 set_target_properties(pcms_transfer PROPERTIES
@@ -54,7 +60,9 @@ target_link_libraries(pcms_transfer PUBLIC
 
 target_link_libraries(pcms_transfer PUBLIC meshfields::meshfields)
 
-target_link_libraries(pcms_transfer PRIVATE PETSc::PETSc)
+if(PCMS_ENABLE_PETSC)
+  target_link_libraries(pcms_transfer PRIVATE PETSc::PETSc)
+endif()
 
 target_compile_definitions(pcms_transfer PUBLIC R3D_USE_KOKKOS)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -401,15 +401,19 @@ if(Catch2_FOUND)
       test_omega_h_field2_outofbounds.cpp)
   endif()
 
-  if (PCMS_ENABLE_MESHFIELDS)
+  if(PCMS_ENABLE_MESHFIELDS)
     list(APPEND PCMS_UNIT_TEST_SOURCES
-	    test_load_vector.cpp
-	    test_mesh_intersection_field_transfer.cpp)
+      test_load_vector.cpp)
+  endif()
+
+  if(PCMS_ENABLE_PETSC)
+    list(APPEND PCMS_UNIT_TEST_SOURCES
+      test_mesh_intersection_field_transfer.cpp)
   endif()
   
   add_executable(unit_tests ${PCMS_UNIT_TEST_SOURCES})
   
-  if (PCMS_ENABLE_MESHFIELDS)
+  if(PCMS_ENABLE_MESHFIELDS)
     target_link_libraries(unit_tests PUBLIC meshfields::meshfields)
   endif()
 
@@ -417,7 +421,9 @@ if(Catch2_FOUND)
           pcms::transfer Kokkos::kokkoskernels)
   target_include_directories(unit_tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-  target_link_libraries(unit_tests PRIVATE PETSc::PETSc)
+  if(PCMS_ENABLE_PETSC)
+    target_link_libraries(unit_tests PRIVATE PETSc::PETSc)
+  endif()
 
   target_link_libraries(unit_tests PUBLIC 
     Catch2::Catch2 

--- a/test/unit_test_main.cpp
+++ b/test/unit_test_main.cpp
@@ -1,15 +1,20 @@
 #include <catch2/catch_session.hpp>
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
+#include <pcms/configuration.h>
+
+#ifdef PCMS_ENABLE_PETSC
 #include <petscsys.h>
+#endif
 
 int main(int argc, char* argv[])
 {
   MPI_Init(&argc, &argv);
   int result = 0;
   {
-    // petsc uses kokkos, so it must be initialized before petsc
+    // PETSc uses Kokkos, so initialize Kokkos before PETSc when enabled.
     Kokkos::ScopeGuard kokkos{argc, argv};
+#ifdef PCMS_ENABLE_PETSC
     PetscBool petsc_initialized = PETSC_FALSE;
     PetscBool petsc_initialized_by_main = PETSC_FALSE;
     PetscInitialized(&petsc_initialized);
@@ -23,6 +28,9 @@ int main(int argc, char* argv[])
     if (petsc_initialized_by_main) {
       PetscFinalize();
     }
+#else
+    result = Catch::Session().run(argc, argv);
+#endif
   }
   MPI_Finalize();
   return result;


### PR DESCRIPTION
This commit fixes the CMake and test headers, so that PCMS can build without having PETSC installed (albeit without the projection methods)