### PR TITLE
frontier: need host/device fn, use kokkos array

### DIFF
--- a/src/pcms/localization/point_search.cpp
+++ b/src/pcms/localization/point_search.cpp
@@ -44,10 +44,11 @@ AABBox<2> triangle_bbox(const Omega_h::Matrix<2, 3>& coords)
 }
 
 template <unsigned dim>
+KOKKOS_INLINE_FUNCTION
 AABBox<dim> simplex_bbox(const Omega_h::Matrix<dim, dim + 1>& coords)
 {
-  std::array<Real, dim> max;
-  std::array<Real, dim> min;
+  Kokkos::Array<Real, dim> max;
+  Kokkos::Array<Real, dim> min;
   for (int j = 0; j < dim; ++j) {
     max[j] = coords(j, 0);
     min[j] = coords(j, 0);
@@ -59,8 +60,8 @@ AABBox<dim> simplex_bbox(const Omega_h::Matrix<dim, dim + 1>& coords)
     }
   }
 
-  std::array<Real, dim> center;
-  std::array<Real, dim> half_width;
+  Kokkos::Array<Real, dim> center;
+  Kokkos::Array<Real, dim> half_width;
 
   for (int j = 0; j < dim; ++j) {
     center[j] = (max[j] + min[j]) / 2.0;

--- a/src/pcms/localization/point_search.cpp
+++ b/src/pcms/localization/point_search.cpp
@@ -44,8 +44,8 @@ AABBox<2> triangle_bbox(const Omega_h::Matrix<2, 3>& coords)
 }
 
 template <unsigned dim>
-KOKKOS_INLINE_FUNCTION
-AABBox<dim> simplex_bbox(const Omega_h::Matrix<dim, dim + 1>& coords)
+KOKKOS_INLINE_FUNCTION AABBox<dim> simplex_bbox(
+  const Omega_h::Matrix<dim, dim + 1>& coords)
 {
   Kokkos::Array<Real, dim> max;
   Kokkos::Array<Real, dim> min;
@@ -209,8 +209,7 @@ template <int dim>
  * Check if a triangle element represented by 3 coordinates in two dimensions
  * intersects with a bounding box
  */
-[[nodiscard]]
-KOKKOS_FUNCTION bool triangle_intersects_bbox(
+[[nodiscard]] KOKKOS_FUNCTION bool triangle_intersects_bbox(
   const Omega_h::Matrix<2, 3>& coords, const AABBox<2>& bbox, Real fuzz)
 {
   // triangle and grid cell bounding box intersect
@@ -235,8 +234,7 @@ KOKKOS_FUNCTION bool triangle_intersects_bbox(
 }
 
 template <unsigned dim>
-[[nodiscard]]
-KOKKOS_FUNCTION bool simplex_intersects_bbox(
+[[nodiscard]] KOKKOS_FUNCTION bool simplex_intersects_bbox(
   const Omega_h::Matrix<dim, dim + 1>& coords, const AABBox<dim>& bbox)
 {
   return intersects(simplex_bbox<dim>(coords), bbox);

--- a/src/pcms/utility/bounding_box.h
+++ b/src/pcms/utility/bounding_box.h
@@ -10,9 +10,9 @@ template <int DIM = 2>
 struct AABBox
 {
   static constexpr int dim = DIM;
-  std::array<Real, dim> center;
+  Kokkos::Array<Real, dim> center;
   // half length of bounding box
-  std::array<Real, dim> half_width;
+  Kokkos::Array<Real, dim> half_width;
 };
 
 template <int dim>

--- a/src/pcms/utility/uniform_grid.h
+++ b/src/pcms/utility/uniform_grid.h
@@ -58,7 +58,7 @@ public:
     auto index = GetDimensionedIndex(idx);
     reverse(index);
 
-    std::array<Real, dim> half_width, center;
+    Kokkos::Array<Real, dim> half_width, center;
 
     for (size_t i = 0; i < dim; ++i) {
       half_width[i] = edge_length[i] / divisions[i] / 2;


### PR DESCRIPTION
This change fixes a compile error (pasted below) on Frontier using `hipcc` (/opt/rocm-6.2.4/lib/llvm/bin/clang++) regarding a device function calling the host only `simplex_bbox(...)` function.  To that end, the use of `std::array` was replaced with `Kokkos::Array` in the functions that use the `AABBox` struct.  

All tests are passing in a local build (with petsc disabled).

``` bash
~/pcms/src/pcms/point_search.cpp:241:21: error: reference to __host__ function 'simplex_bbox<3U>' in __host__ __device__ function                                                                                                                                                                                                                             
  241 |   return intersects(simplex_bbox<dim>(coords), bbox);                                                                                                                                  
      |                     ^                                                                                                                                                                  
~/pcms/src/pcms/point_search.cpp:340:11: note: called by 'operator()'                                                                                                                                                                                                                                                                                         
  340 |       if (simplex_intersects_bbox<3>(vertex_coords, grid_cell_bbox)) {                                                                                                                                                                                                                                                                                                                
      |           ^                                                                                                                                                                                                                                                                                                                                                                           
~/pcmsDev/builds/AMD_GFX90A/kokkos/install/include/Kokkos_Crs.hpp:316:19: note: called by 'operator()'                                                                                                                                                                                                                                                     
  316 |     m_counts(i) = m_functor(i, nullptr);                                                                                                                                                                                                                                                                                                                                              
      |                   ^                                                                                                                                                                    
~/pcmsDev/builds/AMD_GFX90A/kokkos/install/include/HIP/Kokkos_HIP_ParallelFor_Range.hpp:50:5: note: called by 'exec_range<Kokkos::CountAndFillBase<Kokkos::Crs<int, Kokkos::HIP, void, int>, pcms::detail::GridTriIntersectionFunctor3D>::Count>'                                                                                                          
   50 |     m_functor(TagType(), i);                                                                                                                                                           
      |     ^                                                                                                                                                                                                                                                                                                                                                                                 
~/pcmsDev/builds/AMD_GFX90A/kokkos/install/include/HIP/Kokkos_HIP_ParallelFor_Range.hpp:70:22: note: called by 'operator()'                                                                                                                                                                                                                                
   70 |       this->template exec_range<WorkTag>(iwork);                                                                                                                                                                                                                                                                                                                                      
      |                      ^                                                                                                                                                                                                                                                                                                                                                                
~/pcmsDev/builds/AMD_GFX90A/kokkos/install/include/HIP/Kokkos_HIP_KernelLaunch.hpp:76:3: note: called by 'hip_parallel_launch_local_memory<Kokkos::Impl::ParallelFor<Kokkos::CountAndFill<Kokkos::Crs<int, Kokkos::HIP, void, int>, pcms::detail::GridTriIntersectionFunctor3D>, Kokkos::RangePolicy<int, Kokkos::HIP, Kokkos::CountAndFillBase<Kokkos::Crs
<int, Kokkos::HIP, void, int>, pcms::detail::GridTriIntersectionFunctor3D>::Count>>>'                                                                                                          
   76 |   driver();                                                                                                                                                                            
      |   ^                                                                                                                                                                                    
~/pcms/src/pcms/point_search.cpp:47:13: note: 'simplex_bbox<3U>' declared here                                                                                 
   47 | AABBox<dim> simplex_bbox(const Omega_h::Matrix<dim, dim + 1>& coords)                                                                                                                  
      |             ^                                                                                                                                                                                                                                                                                                                                                                         
1 error generated when compiling for gfx90a.                                                                
```