### PR TITLE
Upgrade petsc to 3.25.2

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -133,7 +133,7 @@ jobs:
       id: clone-petsc
       run: |
         cd ${{ runner.temp }}
-        git clone -b v3.24.2 https://gitlab.com/petsc/petsc.git petsc-openmpi
+        git clone -b v3.25.2 https://gitlab.com/petsc/petsc.git petsc-openmpi
         cd petsc-openmpi
         echo "petsc-commit-hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -185,7 +185,7 @@ jobs:
       id: clone-petsc
       run: |
         cd ${{ runner.temp }}
-        git clone -b v3.24.2 https://gitlab.com/petsc/petsc.git petsc
+        git clone -b v3.25.2 https://gitlab.com/petsc/petsc.git petsc
         cd petsc
         echo "petsc-commit-hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
PETSc 3.24.2 incorrectly reads C++17 from the Kokkos cmake config when Kokkos is compiled with C++20. This causes compilation errors when building code that depends on C++20 features. It is unclear why this did not cause issues previously, but upgrading to PETSc 3.25.2 resolves the problem.