### PR TITLE
style: clang-format linear_interpolant.hpp and adj_search.hpp

### DIFF
--- a/src/pcms/localization/adj_search.hpp
+++ b/src/pcms/localization/adj_search.hpp
@@ -22,9 +22,10 @@ private:
 
 public:
   FindSupports(Omega_h::Mesh& source_mesh_, Omega_h::Mesh& target_mesh_)
-    : source_mesh(source_mesh_), target_mesh(target_mesh_){};
+    : source_mesh(source_mesh_), target_mesh(target_mesh_) {};
 
-  FindSupports(Omega_h::Mesh& mesh_) : source_mesh(mesh_), target_mesh(mesh_){};
+  FindSupports(Omega_h::Mesh& mesh_)
+    : source_mesh(mesh_), target_mesh(mesh_) {};
 
   void adjBasedSearch(Omega_h::Write<Omega_h::LO>& supports_ptr,
                       Omega_h::Write<Omega_h::LO>& nSupports,

--- a/src/pcms/transfer/linear_interpolant.hpp
+++ b/src/pcms/transfer/linear_interpolant.hpp
@@ -114,7 +114,7 @@ public:
     : parametric_coords(parametric_coords_),
       values(values_),
       indices(indices_),
-      dimensions(dimensions_){};
+      dimensions(dimensions_) {};
 
   RealVecView linear_interpolation()
   {


### PR DESCRIPTION
reformat headers with clang-format-18