### PR TITLE
Added BVH accelerated point localization and updated localization API

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ cmake -S redev -B build-redev \
   -DADIOS2_DIR=$PWD/build-ADIOS2/install/lib64/cmake/adios2 \
   -Dperfstubs_DIR=$PWD/build-perfstubs/install/lib/cmake
 cmake --build build-redev --target install
+
+git clone git@github.com:arborx/ArborX.git
+cmake -S ArborX -B build-ArborX -D CMAKE_INSTALL_PREFIX="$PWD/build-ArborX/install" \
+-D ARBORX_ENABLE_MPI=ON \
+-D Kokkos_ROOT="$PWD/build-kokkos/install" \
+-D CMAKE_CXX_COMPILER=mpicxx \
+-D CMAKE_CXX_EXTENSIONS=OFF 
+cmake --build build-ArborX --target install
 ```
 ### Build dependencies with CUDA
 ```
@@ -164,6 +172,14 @@ git clone git@github.com:catchorg/Catch2
 cmake -S Catch2 -B build-Catch2 \
   -DCMAKE_INSTALL_PREFIX=$PWD/build-Catch2/install
 cmake --build build-Catch2 --target install
+
+git clone git@github.com:arborx/ArborX.git
+cmake -S ArborX -B build-ArborX -D CMAKE_INSTALL_PREFIX="$PWD/build-ArborX/install" \
+-D ARBORX_ENABLE_MPI=ON \
+-D Kokkos_ROOT="$PWD/build-kokkos/install" \
+-D CMAKE_CXX_COMPILER="$PWD/build-kokkos/install/bin/nvcc_wrapper" \
+-D CMAKE_CXX_EXTENSIONS=OFF
+cmake --build build-ArborX --target install
 ```
 ### Build, install, and test pcms
 ```
@@ -181,6 +197,7 @@ cmake -S pcms -B build-pcms \
   -Dperfstubs_DIR=$PWD/build-perfstubs/install/lib/cmake \
   -DCatch2_DIR=$PWD/build-Catch2/install/lib64/cmake/Catch2/ \
   -DKokkosKernels_DIR=$PWD/build-kokkos-kernels/install/lib64/cmake/KokkosKernels/ \
+  -DArborX_DIR=$PWD/build-ArborX/install/share/cmake/ArborX \
   -DPCMS_TEST_DATA_DIR=$PWD/pcms_testcases
 cmake --build build-pcms -j 8
 

--- a/src/pcms/field/evaluator/omega_h_lagrange.h
+++ b/src/pcms/field/evaluator/omega_h_lagrange.h
@@ -65,13 +65,11 @@ struct CopyCoordsFunctor
 template <int Dim>
 OmegaHLagrangeLocHint BuildLagrangeLocHint(
   Omega_h::Mesh& mesh, int mesh_dim,
-  Kokkos::View<typename PointLocalizationSearch<Dim>::Result*,
-               DeviceMemorySpace>
-    results,
+  PointSearch::Results& results,
   Kokkos::View<Real**, DeviceMemorySpace> coords_d,
   Kokkos::View<LO*, DeviceMemorySpace> owning_ids, OutOfBoundsMode mode)
 {
-  LO n = static_cast<LO>(results.size());
+  LO n = static_cast<LO>(results.dimensionalities.size());
 
   // First pass: count valid and missing
   Kokkos::View<int*, DeviceMemorySpace> is_valid("is_valid", n);
@@ -79,7 +77,7 @@ OmegaHLagrangeLocHint BuildLagrangeLocHint(
     "CheckValidity",
     Kokkos::RangePolicy<typename DeviceMemorySpace::execution_space>(0, n),
     KOKKOS_LAMBDA(LO i) {
-      bool out = (owning_ids(i) < 0) || (results(i).element_id < 0);
+      bool out = (owning_ids(i) < 0) || (results.element_ids(i) < 0);
       is_valid(i) = out ? 0 : 1;
     });
 
@@ -344,7 +342,7 @@ public:
         detail::CopyCoordsFunctor<Dim> copy_functor(coords_d, raw_coords);
         Kokkos::parallel_for("copy_coords", n_pts, copy_functor);
 
-        auto results_d = search(coords_d);
+        auto results_d = search.apply(coords);
         auto owning_ids = search.GetOwningElementIds(results_d);
 
         return detail::BuildLagrangeLocHint<Dim>(

--- a/src/pcms/field/uniform_grid_binary_field.h
+++ b/src/pcms/field/uniform_grid_binary_field.h
@@ -47,7 +47,7 @@ CreateUniformGridBinaryField(Omega_h::Mesh& mesh, const UniformGrid<Dim>& grid)
   auto coords = coord_view.GetValues();
   LO n = layout->GetNumOwnedDofHolder();
 
-  Kokkos::View<Real* [Dim]> coords_d("coords_d", n);
+  Kokkos::View<Real**> coords_d("coords_d", n, Dim);
   Kokkos::parallel_for(
     "CopyCoords", Kokkos::RangePolicy<>(0, n), KOKKOS_LAMBDA(int i) {
       for (int d = 0; d < Dim; ++d) {
@@ -56,21 +56,21 @@ CreateUniformGridBinaryField(Omega_h::Mesh& mesh, const UniformGrid<Dim>& grid)
     });
 
   // Run point-in-mesh search
-  Kokkos::View<typename PointLocalizationSearch<Dim>::Result*> results_d;
+  PointSearch::Results results_d;
   if constexpr (Dim == 2) {
     GridPointSearch2D search(mesh, grid.divisions[0], grid.divisions[1]);
-    results_d = search(coords_d);
+    results_d = search.apply(pcms::CoordinateView(pcms::CoordinateSystem::Cartesian, pcms::MakeConstRank2View(coords_d)));
   } else {
     GridPointSearch3D search(mesh, grid.divisions[0], grid.divisions[1],
                              grid.divisions[2]);
-    results_d = search(coords_d);
+    results_d = search.apply(pcms::CoordinateView(pcms::CoordinateSystem::Cartesian, pcms::MakeConstRank2View(coords_d)));
   }
-  auto results_h =
-    Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, results_d);
+  auto result_ids_h =
+    Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, results_d.element_ids);
 
   Kokkos::View<Real*, HostMemorySpace> data("binary_mask", n);
   for (LO i = 0; i < n; ++i)
-    data(i) = (results_h(i).element_id >= 0) ? 1.0 : 0.0;
+    data(i) = (result_ids_h(i) >= 0) ? 1.0 : 0.0;
 
   field.SetDOFHolderDataHost(
     Rank2View<const Real, HostMemorySpace>(data.data(), n, 1));

--- a/src/pcms/localization/CMakeLists.txt
+++ b/src/pcms/localization/CMakeLists.txt
@@ -7,6 +7,7 @@ set(
         localization_factory.h
         point_cloud_localization.h
         mesh_localization.h
+        point_localization.h
 )
 
 set(
@@ -15,7 +16,9 @@ set(
         adj_search.cpp
         mls_support_helpers.cpp
         mesh_localization.cpp
+        point_localization.cpp
 )
+find_package(ArborX REQUIRED)
 add_library(pcms_localization ${PCMS_LOCALIZATION_SOURCES})
 add_library(pcms::localization ALIAS pcms_localization)
 target_include_directories(
@@ -32,6 +35,7 @@ target_link_libraries(
         pcms::utility
         pcms::discretization
         Omega_h::omega_h
+        ArborX::ArborX
 )
 target_compile_features(pcms_localization PUBLIC cxx_std_20)
 

--- a/src/pcms/localization/adj_search.cpp
+++ b/src/pcms/localization/adj_search.cpp
@@ -7,7 +7,7 @@ namespace pcms
 // Debug helper retained intentionally: useful for diagnosing point-localization
 // failures while developing support-search logic.
 [[maybe_unused]] static void checkTargetPoints(
-  const Kokkos::View<pcms::GridPointSearch2D::Result*>& results,
+  const GridPointSearch2D::Results& results,
   const Kokkos::View<pcms::LO*>& owning_cell_ids)
 {
   Kokkos::fence();
@@ -22,7 +22,7 @@ namespace pcms
       printf("%d, ", i);
     }
   };
-  Omega_h::parallel_for(results.size(), check_target_points,
+  Omega_h::parallel_for(results.dimensionalities.size(), check_target_points,
                         "check_target_points");
   Kokkos::fence();
   pcms::printInfo("\n");
@@ -81,8 +81,8 @@ static Omega_h::Write<Omega_h::LO> locate_target_cells(
     Omega_h::Write<Omega_h::LO>(nvertices_target, -1, "source cell ids");
 
   if (dim == 2) {
-    Kokkos::View<Omega_h::Real* [2]> target_points("target_points",
-                                                   nvertices_target);
+    Kokkos::View<pcms::Real**> target_points("target_points",
+                                                   nvertices_target, 2);
     Omega_h::parallel_for(
       nvertices_target, OMEGA_H_LAMBDA(const Omega_h::LO i) {
         target_points(i, 0) = target_coords[i * dim];
@@ -90,8 +90,10 @@ static Omega_h::Write<Omega_h::LO> locate_target_cells(
       });
     Kokkos::fence();
 
-    pcms::GridPointSearch2D search_cell(source_mesh, 10, 10);
-    auto results = search_cell(target_points);
+    pcms::GridPointSearch2D search_cell(source_mesh, 10, 10); //
+    auto results = search_cell.apply(pcms::CoordinateView(
+		pcms::CoordinateSystem::Cartesian,
+		pcms::MakeConstRank2View(target_points)));
     auto owning_cell_ids = search_cell.GetOwningElementIds(results);
     Omega_h::parallel_for(
       nvertices_target, OMEGA_H_LAMBDA(const Omega_h::LO i) {
@@ -103,8 +105,8 @@ static Omega_h::Write<Omega_h::LO> locate_target_cells(
         source_cell_ids[i] = source_cell_id;
       });
   } else if (dim == 3) {
-    Kokkos::View<Omega_h::Real* [3]> target_points("target_points",
-                                                   nvertices_target);
+    Kokkos::View<pcms::Real**> target_points("target_points",
+                                                   nvertices_target, 3);
     Omega_h::parallel_for(
       nvertices_target, OMEGA_H_LAMBDA(const Omega_h::LO i) {
         target_points(i, 0) = target_coords[i * dim];
@@ -114,7 +116,9 @@ static Omega_h::Write<Omega_h::LO> locate_target_cells(
     Kokkos::fence();
 
     pcms::GridPointSearch3D search_cell(source_mesh, 10, 10, 10);
-    auto results = search_cell(target_points);
+    auto results = search_cell.apply(pcms::CoordinateView(
+		pcms::CoordinateSystem::Cartesian,
+		pcms::MakeConstRank2View(target_points)));
     auto owning_cell_ids = search_cell.GetOwningElementIds(results);
     Omega_h::parallel_for(
       nvertices_target, OMEGA_H_LAMBDA(const Omega_h::LO i) {

--- a/src/pcms/localization/point_localization.cpp
+++ b/src/pcms/localization/point_localization.cpp
@@ -1,0 +1,449 @@
+#include "point_localization.h"
+
+#define FACE_TOL 10e-8
+#define EDGE_TOL 10e-6
+#define VERT_TOL 10e-5
+
+#define kronecker(i,j) (int)(i==j)
+
+// adds template parameters required by ArborX Access traits
+template <typename DeviceType, int dim, class coord = float>
+struct Omega_h_Mesh_Tagged
+{
+	const Omega_h::Mesh & m;
+};
+
+// Access traits for Omega_h
+// constructs bounding boxes for elements
+template <typename DeviceType, int dim, class coord>
+struct ArborX::AccessTraits<Omega_h_Mesh_Tagged<DeviceType, dim, coord>>
+{
+	using memory_space = typename DeviceType::memory_space;
+
+	static KOKKOS_FUNCTION int size(const Omega_h_Mesh_Tagged<DeviceType, dim, coord>& mesh)
+	{
+		return mesh.m.nelems();
+	}
+
+	static KOKKOS_FUNCTION auto get(const Omega_h_Mesh_Tagged<DeviceType, dim, coord>& mesh, int i)
+	{
+		const auto face2verts = mesh.m.get_adj(dim, Omega_h::VERT).ab2b;
+		const auto vert_coords = mesh.m.coords();
+		ArborX::Point<dim, coord> min = {INFINITY};
+		ArborX::Point<dim, coord> max = {-INFINITY};
+		for (int j = 0; j < dim + 1; ++j)
+		{
+			auto cell_vert_id = face2verts[(dim+1)*i+j];
+			for (int k = 0; k < dim; ++k)
+			{
+				coord curr_coord = vert_coords[cell_vert_id*dim+k];
+				if (min[k] > curr_coord) min[k] = curr_coord;
+				if (max[k] < curr_coord) max[k] = curr_coord;
+			}
+		}
+		return ArborX::Box(min, max);
+	}
+};
+
+// adds template parameters required by ArborX Access traits
+template <typename MemorySpace, int dim>
+struct pcms_Coordinate_View_Tagged
+{
+	const pcms::CoordinateView<MemorySpace>& cv;
+};
+
+template <typename MemorySpace, int DIM>
+struct ArborX::AccessTraits<pcms_Coordinate_View_Tagged<MemorySpace, DIM>>
+{
+	using memory_space = MemorySpace;
+	static KOKKOS_FUNCTION int size(pcms_Coordinate_View_Tagged<MemorySpace, DIM> const &coords)
+	{
+		return coords.cv.GetCoordinates().extent(0);
+	}
+	static KOKKOS_FUNCTION auto get(
+		pcms_Coordinate_View_Tagged<MemorySpace, DIM> const &coords, 
+		int i)
+	{
+		const auto points = coords.cv.GetCoordinates();
+		constexpr int dim = DIM;
+		ArborX::Point<dim, double> ax_point;
+		for (int j = 0; j < dim; j++) ax_point[j] = points(i,j);
+		return PredicateWithAttachment(intersects(ax_point), i);
+	}
+};
+
+namespace pcms
+{
+
+/**
+* @brief Constructs a barycentric mapping of a triangle in an Omega_h::Mesh
+* @param elem_index the index of the desired triangle or tetrahedron in the Omega_h::Mesh
+* @param mesh the Omega_h::Mesh with the spatial information of the triangle
+*/
+Mapping2D::Mapping2D(int elem_index, Omega_h::Mesh const& mesh)
+{
+	set_mesh_triangle(elem_index, mesh);
+	bary_transform = { triangle[0] - triangle[2], triangle[1] - triangle[2] };
+	triangle_area = 0.5*fabs(Omega_h::determinant(bary_transform));
+	bary_transform = Omega_h::invert(bary_transform);
+}
+
+/**
+	* @brief Computes the barycentric coordinates of a point in global space
+	* @param p the point to compute the barycentric coordinates of
+	* @returns an Omega_h::Vector<dim + 1> containing the barycentric coordinates
+	* 			of p
+	*/
+KOKKOS_FUNCTION
+Omega_h::Vector<Mapping2D::DIM + 1> Mapping2D::get_bary(Omega_h::Vector<Mapping2D::DIM> const& p) const
+{
+	Omega_h::Vector<2> coeffs = bary_transform*(p - triangle[2]);
+	return {coeffs[0], coeffs[1], 1 - coeffs[0] - coeffs[1]};
+}
+
+int Mapping2D::which(int dim, 
+					 Omega_h::Vector<Mapping2D::DIM + 1> const& bary_coords) const
+{
+	if (dim == Omega_h::VERT) {
+		return which_vert(bary_coords);
+	}
+	if (dim == Omega_h::EDGE) {
+		return which_edge(bary_coords);
+	}
+	if (dim == Omega_h::FACE) {
+		return within_elem(bary_coords);
+	}
+	return -1;
+}
+
+/**
+	* @brief Computes the vertex offset of the point corresponding 
+	* 		  to the input barycentric coordinates
+	* @param bary_coords the input barycentric coordinates
+	* @returns the vertex offset if the point corresponding to the given bary. coordinates
+	* 			is within a certain (global) tolerance of a vertex
+	* 			-1 if the point does not lie within the tolerance of any vertex
+	*/
+int Mapping2D::which_vert(Omega_h::Vector<Mapping2D::DIM + 1> const& bary_coords) const
+{
+	for (int i = 0; i < 3; i++)
+	{
+		// distance of the point to vertex i
+		Omega_h::Vector<2> error = (bary_coords[0] - kronecker(i,0)) * triangle[0] 
+									+ (bary_coords[1] - kronecker(i,1)) * triangle[1] 
+									+ (bary_coords[2] - kronecker(i,2)) * triangle[2];
+		if (Omega_h::norm_squared(error) <= VERT_TOL*VERT_TOL) return i;
+	}
+	return -1;
+}
+
+/**
+* @brief Computes the edge offset of the point corresponding 
+* 		 to the input barycentric coordinates
+* @param bary_coords the input barycentric coordinates
+* @returns the edge offset if the distnce from the point corresponding to the 
+* 			given bary. coordinates to the edge with the respective offset
+* 			is within a certain (global) tolerance
+* 			-1 if the point does not lie within the tolerance of any vertex
+*/
+int Mapping2D::which_edge(Omega_h::Vector<Mapping2D::DIM + 1> const& bary_coords) const
+{
+	for (int i = 0; i <= 2; i++)
+	{
+		// Distance of the point to the edge opposite the ith vertex,
+		// see docs for derivation.
+		double dist = (2*bary_coords[i]*triangle_area)*(2*bary_coords[i]*triangle_area);
+		dist /= opposite_edge_len_sq(i);
+		if (dist <= EDGE_TOL*EDGE_TOL &&
+			bary_coords[(i+1)%3] >= 0 && bary_coords[(i+2)%3] >= 0) return (i+1)%3;
+	}
+	return -1;
+}
+
+/**
+* @brief Computes whether a point with the given barycentric coordinates
+* 		  is within a triangle
+* @param bary_coords the input barycentric coordinates
+* @returns 0 if the point is within the highet order element and -1 otherwise
+*/
+int Mapping2D::within_elem(Omega_h::Vector<Mapping2D::DIM + 1> const& bary_coords) const
+{
+	return -1 * (int)(bary_coords[0] > 0 && bary_coords[1] > 0 && bary_coords[2] > 0);
+}
+
+/**
+* @brief Constructs the triangle the mapping is for
+* @param index the element ID of the triangle
+* @param mesh the Omega_h::Mesh with the spatial information for the triangle
+* 			   corresponding to index
+*/
+void Mapping2D::set_mesh_triangle(int index, Omega_h::Mesh const& mesh)
+{
+	auto face2vert = mesh.get_adj(Omega_h::FACE, Omega_h::VERT).ab2b;
+	auto vert_coords = mesh.coords();
+	triangle = Omega_h::Matrix<2,3>{{vert_coords[face2vert[index*3]*2], vert_coords[face2vert[index*3]*2 + 1]},
+			{vert_coords[face2vert[index*3 + 1]*2], vert_coords[face2vert[index*3 + 1]*2 + 1]},
+			{vert_coords[face2vert[index*3 + 2]*2], vert_coords[face2vert[index*3 + 2]*2 + 1]}};
+}
+
+/**
+* @brief Calculates the length of the edge opposite vertex i
+* @param i the vertex index opposite the desired edge
+* @returns the length of the ith edge
+*/
+double Mapping2D::opposite_edge_len_sq(int i) const
+{
+	return Omega_h::norm_squared(triangle[(i+2)%3] - triangle[(i+1)%3]);
+}
+
+/**
+* @brief Constructs a barycentric mapping of a triangle in an Omega_h::Mesh
+* @param elem_index the index of the desired triangle or tetrahedron in the Omega_h::Mesh
+* @param mesh the Omega_h::Mesh with the spatial information of the triangle
+*/
+Mapping3D::Mapping3D(int elem_index, Omega_h::Mesh const& mesh)
+{
+	set_mesh_tet(elem_index, mesh);
+	set_triangle_areas();
+	bary_transform = { tetrahedron[0] - tetrahedron[3], tetrahedron[1] - tetrahedron[3], tetrahedron[2] - tetrahedron[3] };
+	tetrahedron_volume = fabs(Omega_h::determinant(bary_transform))/6.;
+	bary_transform = Omega_h::invert(bary_transform);
+}
+
+/**
+* @brief Computes the barycentric coordinates of a point in global space
+* @param p the point to compute the barycentric coordinates of
+* @returns an Omega_h::Vector<dim + 1> containing the barycentric coordinates
+* 			of p
+*/
+Omega_h::Vector<Mapping3D::DIM + 1> Mapping3D::get_bary(Omega_h::Vector<Mapping3D::DIM> const& p) const
+{
+	Omega_h::Vector<3> coeffs = bary_transform*(p - tetrahedron[3]);
+	return {coeffs[0], coeffs[1], coeffs[2], 1 - coeffs[0] - coeffs[1] - coeffs[2]};
+}
+
+int Mapping3D::which(int dim, 
+					 Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords) const
+{
+	if (dim == Omega_h::VERT) {
+		return which_vert(bary_coords);
+	}
+	if (dim == Omega_h::EDGE) {
+		return which_edge(bary_coords);
+	}
+	if (dim == Omega_h::FACE) {
+		return which_face(bary_coords);
+	}
+	if (dim == Omega_h::REGION) {
+		return within_elem(bary_coords);
+	}
+	return -1;
+}
+
+/**
+* @brief Computes the vertex offset of the point corresponding 
+		to the input barycentric coordinates
+* @param bary_coords the input barycentric coordinates
+* @returns the vertex offset if the point corresponding to the given bary. coordinates
+* 			is within a certain (global) tolerance of a vertex
+* 			-1 if the point does not lie within the tolerance of any vertex
+*/
+int Mapping3D::which_vert(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords) const
+{
+	for (int i = 0; i < 4; i++)
+	{
+		// distance to the ith vertex
+		Omega_h::Vector<3> error = (bary_coords[0] - kronecker(i,0)) * tetrahedron[0] + (bary_coords[1] - kronecker(i,1)) * tetrahedron[1]
+									+ (bary_coords[2] - kronecker(i,2)) * tetrahedron[2] + (bary_coords[3] - kronecker(i,3)) * tetrahedron[3];
+		if (Omega_h::norm_squared(error) <= VERT_TOL*VERT_TOL) return i;
+	}
+	return -1;
+}
+
+/**
+* @brief Computes the edge offset of the point corresponding 
+* 		 to the input barycentric coordinates
+* @param bary_coords the input barycentric coordinates
+* @returns the edge offset if the distnce from the point corresponding to the 
+* 			given bary. coordinates to the edge with the respective offset
+* 			is within a certain (global) tolerance
+* 			-1 if the point does not lie within the tolerance of any vertex
+*/
+int Mapping3D::which_edge(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords) const
+{
+	int edge_ = 0;
+	for (int i = 0; i < 4; i++)
+	{
+		for (int j = i+1; j < 4; j++)
+		{
+			Omega_h::Vector<3> side1 = {0,0,0}, side2 = {0,0,0}, side3 = tetrahedron[i] - tetrahedron[j];
+			for (int k = 0; k < 4; k++)
+			{
+				side1 += (bary_coords[k] - kronecker(i,k)) * tetrahedron[k];
+				side2 += (bary_coords[k] - kronecker(j,k)) * tetrahedron[k];
+			}
+
+			// the norm of the cross product of two vectors is twice the area of the triangle
+			// those vectors form
+			double distnce_sq = Omega_h::norm_squared(Omega_h::cross(side1, side2));
+			distnce_sq /= Omega_h::norm_squared(side3);
+			
+			if (distnce_sq <= EDGE_TOL*EDGE_TOL && bary_coords[i] > 0 && bary_coords[j] > 0) return edge(edge_);
+			edge_++;
+		}
+	}
+	return -1;
+}
+
+/**
+* @brief Computes the face offset of the point corresponding 
+* 		 to the input barycentric coordinates
+* @param bary_coords the input barycentric coordinates
+* @returns if the point corresponding to the bary. coords is within a 
+* 			global tolerance of a face, returns the offset of that face
+* 			-1 if the point does not lie within the tolerance of any face
+* Algorithm source:
+* C.E. Passerello,
+* Interference detection using barycentric coordinates,
+* Mechanics Research Communications,
+* Volume 9, Issue 6, 1982, Pages 373-378,
+* https://doi.org/10.1016/0093-6413(82)90034-9.
+*/
+int Mapping3D::which_face(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords) const
+{
+	for (int i = 0; i < 4; i++)
+	{
+		if (fabs(3*tetrahedron_volume*bary_coords[i]/face_areas[i]) <= FACE_TOL
+			&& bary_coords[(i+1)%4] >= 0 && bary_coords[(i+2)%4] >= 0 && bary_coords[(i+3)%4] >= 0)
+		{
+			return face(i);
+		}
+	}
+	return -1;
+}
+	
+/**
+* @brief Computes whether a point with the given barycentric coordinates
+* 		  is within a triangle
+* @param bary_coords the input barycentric coordinates
+* @returns 0 if the point is within the highet order element and -1 otherwise
+*/
+int Mapping3D::within_elem(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords) const
+{
+	return -1 * (int)(bary_coords[0] >= 0 && bary_coords[1] >= 0 && bary_coords[2] >= 0 && bary_coords[3] >= 0);
+}
+
+// constructs the tetrahedron from the mesh's spatial data
+void Mapping3D::set_mesh_tet(int index, Omega_h::Mesh const& mesh)
+{
+	auto region2vert = mesh.get_adj(Omega_h::REGION, Omega_h::VERT).ab2b;
+	auto vert_coords = mesh.coords();
+	tetrahedron = {{vert_coords[region2vert[index*4]*3], vert_coords[region2vert[index*4]*3 + 1], vert_coords[region2vert[index*4]*3 + 2]},
+	{vert_coords[region2vert[index*4 + 1]*3], vert_coords[region2vert[index*4 + 1]*3 + 1], vert_coords[region2vert[index*4 + 1]*3 + 2]},
+	{vert_coords[region2vert[index*4 + 2]*3], vert_coords[region2vert[index*4 + 2]*3 + 1], vert_coords[region2vert[index*4 + 2]*3 + 2]},
+	{vert_coords[region2vert[index*4 + 3]*3], vert_coords[region2vert[index*4 + 3]*3 + 1], vert_coords[region2vert[index*4 + 3]*3 + 2]}};
+}
+
+// calculates the areas of each of the faces of the triangle
+// the faces are "named" according to the vertex opposite
+// (i.e., face 0 is defined by points 1, 2, 3)
+void Mapping3D::set_triangle_areas()
+{
+	for (int i = 0; i < 4; i++)
+	{
+		Omega_h::Vector<3> edge0 = tetrahedron[(i+1)%4] - tetrahedron[(i+3)%4], edge1 = tetrahedron[(i+2)%4] - tetrahedron[(i+3)%4];
+		Omega_h::Vector<3> cross = Omega_h::cross(edge0, edge1);
+		face_areas[i] = 0.5*Omega_h::norm(cross);
+	}
+}
+
+TreePointSearch2D::TreePointSearch2D(const Omega_h::Mesh& mesh) : mesh_(mesh)
+{
+	if (mesh.dim() != 2) 
+	{
+		throw pcms_error("Could not construct TreePointSearch2D, invalid mesh dimension");
+	}
+
+	Omega_h::ExecSpace execution_space;
+	using DeviceType = Kokkos::Device<Omega_h::ExecSpace, 
+									  Omega_h::ExecSpace::memory_space>;
+	Omega_h_Mesh_Tagged<DeviceType, 2, double> tagged_mesh{mesh};
+	tree = ArborX::BVH(execution_space, 
+						ArborX::Experimental::attach_indices(tagged_mesh));
+
+	mappings = Kokkos::View<Mapping2D*, Omega_h::ExecSpace::memory_space>("mappings", mesh.nelems());
+	auto mappings_h = Kokkos::create_mirror_view(mappings);
+	for (int i = 0; i < mesh.nelems(); i++)
+	{
+		mappings_h[i] = Mapping2D(i, mesh);
+	}
+	Kokkos::deep_copy(execution_space, mappings, mappings_h);
+}
+
+Kokkos::View<PointSearch2D::Result*> TreePointSearch2D::apply(
+	const CoordinateView<Omega_h::ExecSpace::memory_space>& coords) const
+{
+	if (coords.GetCoordinateSystem() != pcms::CoordinateSystem::Cartesian)
+	{
+		throw pcms_error("TreePointSearch2D::apply only implemented for"
+						 " Cartesian coordinates");
+	}
+	
+	Omega_h::ExecSpace execution_space;
+	Kokkos::View<PointSearch2D::Result*> intersection_results("2D intersection results",
+																coords.GetCoordinates().extent(0));
+	auto results_h = Kokkos::create_mirror_view(intersection_results);
+	for (int i = 0; i < intersection_results.size(); i++) 
+		results_h[i] = Result_t{
+			.dimensionality = Dim_t::REGION,
+			.element_id = -1,
+			.parametric_coords = {-1, -1, -1}
+		};
+	Kokkos::deep_copy(execution_space, intersection_results, results_h);
+
+	auto CallOnIntersect = KOKKOS_LAMBDA <typename Predicate, typename Value>
+	(Predicate const &predicate, Value const & val)
+	{
+		ArborX::Point<2, Omega_h::Real> const& ax = ArborX::getGeometry(predicate);
+		Omega_h::Vector<2> point{ax[0], ax[1]};
+		int point_ind = ArborX::getData(predicate);
+		
+		Mapping2D const& tm = mappings(val.index);
+		
+		// calculate the barycentric coefficients of the point
+		auto coeffs = tm.get_bary(point);
+
+		for (int i = 0; i < DIM; i++)
+		{
+			int elem = tm.which(i, coeffs);
+			if (elem >= 0 && intersection_results(point_ind).dimensionality > (Dim_t)i)
+			{
+				auto face2elem = mesh_.get_adj(Omega_h::FACE, i).ab2b;
+				auto elem_ind = face2elem[3*val.index + elem];
+				intersection_results(point_ind) = PointSearch2D::Result{
+					.dimensionality = (Dim_t)i, 
+					.element_id = elem_ind, 
+					.parametric_coords = coeffs
+				};
+				return;
+			}
+		}
+		if (tm.which(DIM, coeffs) >= 0 && intersection_results(point_ind).dimensionality > (Dim_t)DIM)
+		{
+			intersection_results(point_ind) = PointSearch2D::Result{
+				.dimensionality = Dim_t::FACE, 
+				.element_id = (LO)val.index, 
+				.parametric_coords = coeffs
+			};
+		}
+	};
+
+	tree.query(execution_space, 
+			   pcms_Coordinate_View_Tagged<Omega_h::ExecSpace::memory_space, 2>{coords},
+			   CallOnIntersect);
+	return intersection_results;
+}
+
+} // namespace pcms
+
+

--- a/src/pcms/localization/point_localization.cpp
+++ b/src/pcms/localization/point_localization.cpp
@@ -254,6 +254,77 @@ void Mapping3D::set_triangle_areas()
 	}
 }
 
+template <typename Predicate, typename Value>
+KOKKOS_FUNCTION void CallOnIntersect2D::operator()(Predicate const &predicate, Value const & val) const
+{
+	ArborX::Point<DIM, Omega_h::Real> const& ax = ArborX::getGeometry(predicate);
+	Omega_h::Vector<DIM> point{ax[0], ax[1]};
+	int point_ind = ArborX::getData(predicate);
+	
+	detail::Mapping2D const& tm = mappings(val.index);
+	
+	// calculate the barycentric coefficients of the point
+	auto coeffs = tm.get_bary(point);
+
+	for (int i = 0; i < DIM; i++)
+	{
+		int elem = tm.which(i, coeffs);
+		if (elem >= 0 && intersection_results(point_ind).dimensionality > (TreePointSearch::Dimensionality)i)
+		{
+			auto elem_ind = adjacencies[i][3*val.index + elem];
+			intersection_results(point_ind).dimensionality = (TreePointSearch::Dimensionality)i;
+			intersection_results(point_ind).element_id = elem_ind;
+			for (int j = 0; j < DIM + 1; j++)
+				intersection_results(point_ind).parametric_coords(j) = coeffs[j];
+			return;
+		}
+	}
+	if (tm.which(DIM, coeffs) >= 0 
+		&& intersection_results(point_ind).dimensionality > TreePointSearch::Dimensionality::FACE)
+	{
+		intersection_results(point_ind).dimensionality = TreePointSearch::Dimensionality::FACE;
+		intersection_results(point_ind).element_id = (LO)val.index;
+		for (int j = 0; j < DIM + 1; j++)
+				intersection_results(point_ind).parametric_coords(j) = coeffs[j];
+	}
+}
+
+template <typename Predicate, typename Value>
+void CallOnIntersect3D::operator()(Predicate const &predicate, Value const & val) const
+{
+	ArborX::Point<DIM, Omega_h::Real> const& ax = ArborX::getGeometry(predicate);
+	Omega_h::Vector<DIM> point{ax[0], ax[1], ax[2]};
+	int point_ind = ArborX::getData(predicate);
+	
+	detail::Mapping3D const& tm = mappings(val.index);
+	
+	// calculate the barycentric coefficients of the point
+	auto coeffs = tm.get_bary(point);
+	int offsets[DIM] = {4, 6, 4};
+	for (int i = 0; i < DIM; i++)
+	{
+		int elem = tm.which(i, coeffs);
+		if (elem >= 0 && intersection_results(point_ind).dimensionality > (TreePointSearch::Dimensionality)i)
+		{
+			auto elem_ind = adjacencies[i][offsets[i]*val.index + elem];
+			intersection_results(point_ind).dimensionality = (TreePointSearch::Dimensionality)i;
+			intersection_results(point_ind).element_id = elem_ind;
+			for (int j = 0; j < DIM + 1; j++)
+				intersection_results(point_ind).parametric_coords(j) = coeffs[j];
+			return;
+		}
+	}
+
+	if (tm.which(DIM, coeffs) >= 0 
+			&& intersection_results(point_ind).dimensionality >= TreePointSearch::Dimensionality::REGION)
+	{
+		intersection_results(point_ind).dimensionality = TreePointSearch::Dimensionality::REGION;
+		intersection_results(point_ind).element_id = (LO)val.index;
+		for (int j = 0; j < DIM + 1; j++)
+				intersection_results(point_ind).parametric_coords(j) = coeffs[j];
+	}
+}
+
 } //namespace detail
 
 Kokkos::View<TreePointSearch::Result*> TreePointSearch::apply(

--- a/src/pcms/localization/point_localization.cpp
+++ b/src/pcms/localization/point_localization.cpp
@@ -164,11 +164,11 @@ int Mapping2D::which_edge(Omega_h::Vector<Mapping2D::DIM + 1> const& bary_coords
 * @brief Computes whether a point with the given barycentric coordinates
 * 		  is within a triangle
 * @param bary_coords the input barycentric coordinates
-* @returns 0 if the point is within the highet order element and -1 otherwise
+* @returns 0 if the point is within the highest order element and -1 otherwise
 */
 int Mapping2D::within_elem(Omega_h::Vector<Mapping2D::DIM + 1> const& bary_coords) const
 {
-	return -1 * (int)(bary_coords[0] > 0 && bary_coords[1] > 0 && bary_coords[2] > 0);
+	return -1 * (int)!(bary_coords[0] > 0 && bary_coords[1] > 0 && bary_coords[2] > 0);
 }
 
 /**
@@ -428,11 +428,12 @@ Kokkos::View<PointSearch2D::Result*> TreePointSearch2D::apply(
 				return;
 			}
 		}
-		if (tm.which(DIM, coeffs) >= 0 && intersection_results(point_ind).dimensionality > (Dim_t)DIM)
+		if (tm.which(DIM, coeffs) >= 0 
+			&& intersection_results(point_ind).dimensionality > Dim_t::FACE)
 		{
 			intersection_results(point_ind) = PointSearch2D::Result{
-				.dimensionality = Dim_t::FACE, 
-				.element_id = (LO)val.index, 
+				.dimensionality = Dim_t::FACE,
+				.element_id = (LO)val.index,
 				.parametric_coords = coeffs
 			};
 		}

--- a/src/pcms/localization/point_localization.cpp
+++ b/src/pcms/localization/point_localization.cpp
@@ -249,23 +249,27 @@ KOKKOS_FUNCTION void CallOnIntersect2D::operator()(Predicate const &predicate, V
 	for (int i = 0; i < DIM; i++)
 	{
 		int elem = tm.which(i, coeffs);
-		if (elem >= 0 && intersection_results(point_ind).dimensionality > (TreePointSearch::Dimensionality)i)
+		if (elem >= 0 && dimensionalities(point_ind) > (TreePointSearch::Dimensionality)i)
 		{
 			auto elem_ind = adjacencies[i][3*val.index + elem];
-			intersection_results(point_ind).dimensionality = (TreePointSearch::Dimensionality)i;
-			intersection_results(point_ind).element_id = elem_ind;
+			dimensionalities(point_ind) = (TreePointSearch::Dimensionality)i;
+			element_ids(point_ind) = elem_ind;
 			for (int j = 0; j < DIM + 1; j++)
-				intersection_results(point_ind).parametric_coords(j) = coeffs[j];
+			{
+				parametric_coords(point_ind, j) = coeffs(j);
+			}
 			return;
 		}
 	}
 	if (tm.which(DIM, coeffs) >= 0 
-		&& intersection_results(point_ind).dimensionality > TreePointSearch::Dimensionality::FACE)
+		&& dimensionalities(point_ind) > TreePointSearch::Dimensionality::FACE)
 	{
-		intersection_results(point_ind).dimensionality = TreePointSearch::Dimensionality::FACE;
-		intersection_results(point_ind).element_id = (LO)val.index;
+		dimensionalities(point_ind) = TreePointSearch::Dimensionality::FACE;
+		element_ids(point_ind) = (LO)val.index;
 		for (int j = 0; j < DIM + 1; j++)
-				intersection_results(point_ind).parametric_coords(j) = coeffs[j];
+		{
+			parametric_coords(point_ind, j) = coeffs(j);
+		}
 	}
 }
 
@@ -284,30 +288,34 @@ void CallOnIntersect3D::operator()(Predicate const &predicate, Value const & val
 	for (int i = 0; i < DIM; i++)
 	{
 		int elem = tm.which(i, coeffs);
-		if (elem >= 0 && intersection_results(point_ind).dimensionality > (TreePointSearch::Dimensionality)i)
+		if (elem >= 0 && dimensionalities(point_ind) > (TreePointSearch::Dimensionality)i)
 		{
 			auto elem_ind = adjacencies[i][offsets[i]*val.index + elem];
-			intersection_results(point_ind).dimensionality = (TreePointSearch::Dimensionality)i;
-			intersection_results(point_ind).element_id = elem_ind;
+			dimensionalities(point_ind) = (TreePointSearch::Dimensionality)i;
+			element_ids(point_ind) = elem_ind;
 			for (int j = 0; j < DIM + 1; j++)
-				intersection_results(point_ind).parametric_coords(j) = coeffs[j];
+			{
+				parametric_coords(point_ind, j) = coeffs(j);
+			}
 			return;
 		}
 	}
 
 	if (tm.which(DIM, coeffs) >= 0 
-			&& intersection_results(point_ind).dimensionality >= TreePointSearch::Dimensionality::REGION)
+			&& dimensionalities(point_ind) > TreePointSearch::Dimensionality::REGION)
 	{
-		intersection_results(point_ind).dimensionality = TreePointSearch::Dimensionality::REGION;
-		intersection_results(point_ind).element_id = (LO)val.index;
+		dimensionalities(point_ind) = TreePointSearch::Dimensionality::REGION;
+		element_ids(point_ind) = (LO)val.index;
 		for (int j = 0; j < DIM + 1; j++)
-				intersection_results(point_ind).parametric_coords(j) = coeffs[j];
+		{
+			parametric_coords(point_ind, j) = coeffs(j);
+		}
 	}
 }
 
 } //namespace detail
 
-Kokkos::View<TreePointSearch::Result*> TreePointSearch::apply(
+TreePointSearch::Results TreePointSearch::apply(
 	const CoordinateView<TreePointSearch::MemorySpace>& coords) const
 {
 	if (coords.GetCoordinateSystem() != pcms::CoordinateSystem::Cartesian)
@@ -315,10 +323,10 @@ Kokkos::View<TreePointSearch::Result*> TreePointSearch::apply(
 		throw pcms_error("TreePointSearch::apply only implemented for"
 						 " Cartesian coordinates");
 	}
-	if (coords.GetCoordinates().extent(1) != mesh_.dim())
+	if (coords.GetValues().extent(1) != mesh_.dim())
 	{
 		throw pcms_error("Input coordinate space dimension " 
-			+ std::to_string(coords.GetCoordinates().extent(1))
+			+ std::to_string(coords.GetValues().extent(1))
 			+ " does not match query space dimension " 
 			+ std::to_string(mesh_.dim()));
 	}
@@ -327,57 +335,59 @@ Kokkos::View<TreePointSearch::Result*> TreePointSearch::apply(
 	{
 		static constexpr int DIM = 2;
 		Omega_h::ExecSpace execution_space;
-		Kokkos::View<PointSearch::Result*, MemorySpace> 
-			intersection_results("2D intersection results",
-				coords.GetCoordinates().extent(0));
-		auto results_h = Kokkos::create_mirror_view(intersection_results);
-		for (int i = 0; i < intersection_results.size(); i++) 
-		{
-			results_h[i].dimensionality = Dimensionality::REGION,
-			results_h[i].element_id = -1,
-			results_h[i].parametric_coords = {-1, -1, -1, -1};
-		}
-		Kokkos::deep_copy(execution_space, intersection_results, results_h);
 
-		tree->get_tree<2>()->query(execution_space, 
-					detail::Coordinate_View_Adapt<MemorySpace, DIM>{
-					coords.GetCoordinates()},
-					detail::CallOnIntersect2D(
-						*tree->get_mappings<2>(),
-						mesh_.get_adj(Omega_h::FACE, 0).ab2b,
-						mesh_.get_adj(Omega_h::FACE, 1).ab2b,
-						intersection_results
-					));
-		return intersection_results;
+		Kokkos::View<TreePointSearch::Dimensionality*, MemorySpace> dims("dimensionalities", coords.GetValues().extent(0));
+		Kokkos::deep_copy(dims, TreePointSearch::Dimensionality::NO_INTERSECT);
+
+		
+		Kokkos::View<LO*, MemorySpace> elem_ids("element IDs", coords.GetValues().extent(0));
+		Kokkos::deep_copy(elem_ids, -1);
+
+		Kokkos::View<Real**, MemorySpace> parametric_coords("parametric coordinates", coords.GetValues().extent(0), coords.GetValues().extent(1) + 1);
+		Kokkos::deep_copy(parametric_coords, -1.0);
+
+
+		tree->get_tree<2>()->query(
+			execution_space, 
+			detail::Coordinate_View_Adapt<MemorySpace, DIM>{coords.GetValues()},
+			detail::CallOnIntersect2D(
+				*tree->get_mappings<2>(),
+				mesh_.get_adj(Omega_h::FACE, 0).ab2b,
+				mesh_.get_adj(Omega_h::FACE, 1).ab2b,
+				dims,
+				elem_ids,
+				parametric_coords
+			));
+		return Results{dims, elem_ids, parametric_coords};
 	}
 	else
 	{
 		static constexpr int DIM = 3;
 		Omega_h::ExecSpace execution_space;
-		Kokkos::View<PointSearch::Result*, MemorySpace> 
-			intersection_results("3D intersection results",
-				coords.GetCoordinates().extent(0));
-		auto results_h = Kokkos::create_mirror_view(intersection_results);
-		for (int i = 0; i < intersection_results.size(); i++) 
-		{
-			results_h[i].dimensionality = Dimensionality::REGION,
-			results_h[i].element_id = -1,
-			results_h[i].parametric_coords = {-1, -1, -1, -1};
-		}
-		Kokkos::deep_copy(execution_space, intersection_results, results_h);
 
-		tree->get_tree<3>()->query(execution_space, 
-			detail::Coordinate_View_Adapt<MemorySpace, 
-			DIM>{
-			coords.GetCoordinates()},
+		Kokkos::View<TreePointSearch::Dimensionality*, MemorySpace> dims("dimensionalities", coords.GetValues().extent(0));
+		Kokkos::deep_copy(dims, TreePointSearch::Dimensionality::NO_INTERSECT);
+
+
+		Kokkos::View<LO*, MemorySpace> elem_ids("element IDs", coords.GetValues().extent(0));
+		Kokkos::deep_copy(elem_ids, -1);
+
+		Kokkos::View<Real**, MemorySpace> parametric_coords("parametric coordinates", coords.GetValues().extent(0), coords.GetValues().extent(1) + 1);
+		Kokkos::deep_copy(parametric_coords, -1.0);
+
+		tree->get_tree<3>()->query(
+			execution_space, 
+			detail::Coordinate_View_Adapt<MemorySpace, DIM>{coords.GetValues()},
 			detail::CallOnIntersect3D(
 				*tree->get_mappings<3>(),
 				mesh_.get_adj(Omega_h::REGION, 0).ab2b,
 				mesh_.get_adj(Omega_h::REGION, 1).ab2b,
 				mesh_.get_adj(Omega_h::REGION, 2).ab2b,
-				intersection_results	
+				dims,
+				elem_ids,
+				parametric_coords
 			));
-		return intersection_results;
+		return Results{dims, elem_ids, parametric_coords};
 	}
 }
 

--- a/src/pcms/localization/point_localization.cpp
+++ b/src/pcms/localization/point_localization.cpp
@@ -1,9 +1,5 @@
 #include "point_localization.h"
 
-#define FACE_TOL 10e-8
-#define EDGE_TOL 10e-6
-#define VERT_TOL 10e-5
-
 // Access traits for Omega_h
 // constructs bounding boxes for elements
 template <int dim>
@@ -62,8 +58,12 @@ namespace pcms
 namespace detail
 {
 
-Mapping<2>::Mapping(Omega_h::Matrix<Mapping<2>::DIM,Mapping<2>::DIM+1> const& triangle_) : triangle(triangle_)
+Mapping<2>::Mapping(
+	Omega_h::Matrix<Mapping<2>::DIM,Mapping<2>::DIM+1> const& triangle_,
+	const Kokkos::View<Real*>& tolerances)
+	: triangle(triangle_)
 {
+	tolerances_ = tolerances;
 	bary_transform = { triangle[0] - triangle[2], triangle[1] - triangle[2] };
 	triangle_area = 0.5*fabs(Omega_h::determinant(bary_transform));
 	bary_transform = Omega_h::invert(bary_transform);
@@ -100,7 +100,7 @@ int Mapping<2>::which_vert(Omega_h::Vector<Mapping<2>::DIM + 1> const& bary_coor
 		Omega_h::Vector<2> error = (bary_coords[0] - kronecker(i,0)) * triangle[0] 
 									+ (bary_coords[1] - kronecker(i,1)) * triangle[1] 
 									+ (bary_coords[2] - kronecker(i,2)) * triangle[2];
-		if (Omega_h::norm_squared(error) <= VERT_TOL*VERT_TOL) return i;
+		if (Omega_h::norm_squared(error) <= tolerances_(0)*tolerances_(0)) return i;
 	}
 	return -1;
 }
@@ -113,7 +113,7 @@ int Mapping<2>::which_edge(Omega_h::Vector<Mapping<2>::DIM + 1> const& bary_coor
 		// see docs for derivation.
 		double dist = (2*bary_coords[i]*triangle_area)*(2*bary_coords[i]*triangle_area);
 		dist /= opposite_edge_len_sq(i);
-		if (dist <= EDGE_TOL*EDGE_TOL &&
+		if (dist <= tolerances_(1)*tolerances_(1) &&
 			bary_coords[(i+1)%3] >= 0 && bary_coords[(i+2)%3] >= 0) return (i+1)%3;
 	}
 	return -1;
@@ -129,9 +129,12 @@ double Mapping<2>::opposite_edge_len_sq(int i) const
 	return Omega_h::norm_squared(triangle[(i+2)%3] - triangle[(i+1)%3]);
 }
 
-Mapping<3>::Mapping(Omega_h::Matrix<Mapping<3>::DIM,Mapping<3>::DIM+1> const& tetrahedron_)
+Mapping<3>::Mapping(
+	Omega_h::Matrix<Mapping<3>::DIM,Mapping<3>::DIM+1> const& tetrahedron_, 
+	const Kokkos::View<Real*>& tolerances)
 	: tetrahedron(tetrahedron_)
 {
+	tolerances_ = tolerances;
 	set_triangle_areas();
 	bary_transform = { tetrahedron[0] - tetrahedron[3], tetrahedron[1] - tetrahedron[3], tetrahedron[2] - tetrahedron[3] };
 	tetrahedron_volume = fabs(Omega_h::determinant(bary_transform))/6.;
@@ -171,7 +174,7 @@ int Mapping<3>::which_vert(Omega_h::Vector<Mapping<3>::DIM + 1> const& bary_coor
 		// distance to the ith vertex
 		Omega_h::Vector<3> error = (bary_coords[0] - kronecker(i,0)) * tetrahedron[0] + (bary_coords[1] - kronecker(i,1)) * tetrahedron[1]
 									+ (bary_coords[2] - kronecker(i,2)) * tetrahedron[2] + (bary_coords[3] - kronecker(i,3)) * tetrahedron[3];
-		if (Omega_h::norm_squared(error) <= VERT_TOL*VERT_TOL) return i;
+		if (Omega_h::norm_squared(error) <= tolerances_(0)*tolerances_(0)) return i;
 	}
 	return -1;
 }
@@ -196,7 +199,7 @@ int Mapping<3>::which_edge(Omega_h::Vector<Mapping<3>::DIM + 1> const& bary_coor
 			double distnce_sq = Omega_h::norm_squared(Omega_h::cross(side1, side2));
 			distnce_sq /= Omega_h::norm_squared(side3);
 			
-			if (distnce_sq <= EDGE_TOL*EDGE_TOL && bary_coords[i] > 0 && bary_coords[j] > 0) return edge(edge_);
+			if (distnce_sq <= tolerances_(1)*tolerances_(1) && bary_coords[i] > 0 && bary_coords[j] > 0) return edge(edge_);
 			edge_++;
 		}
 	}
@@ -207,7 +210,7 @@ int Mapping<3>::which_face(Omega_h::Vector<Mapping<3>::DIM + 1> const& bary_coor
 {
 	for (int i = 0; i < 4; i++)
 	{
-		if (fabs(3*tetrahedron_volume*bary_coords[i]/face_areas[i]) <= FACE_TOL
+		if (fabs(3*tetrahedron_volume*bary_coords[i]/face_areas[i]) <= tolerances_(2)
 			&& bary_coords[(i+1)%4] >= 0 && bary_coords[(i+2)%4] >= 0 && bary_coords[(i+3)%4] >= 0)
 		{
 			return face(i);
@@ -347,11 +350,11 @@ TreePointSearch::Results TreePointSearch::apply(
 		Kokkos::deep_copy(parametric_coords, -1.0);
 
 
-		tree->get_tree<2>()->query(
+		tree->get_tree<2>().query(
 			execution_space, 
 			detail::Coordinate_View_Adapt<MemorySpace, DIM>{coords.GetValues()},
 			detail::CallOnIntersect2D(
-				*tree->get_mappings<2>(),
+				tree->get_mappings<2>(),
 				mesh_.get_adj(Omega_h::FACE, 0).ab2b,
 				mesh_.get_adj(Omega_h::FACE, 1).ab2b,
 				dims,
@@ -375,11 +378,11 @@ TreePointSearch::Results TreePointSearch::apply(
 		Kokkos::View<Real**, MemorySpace> parametric_coords("parametric coordinates", coords.GetValues().extent(0), coords.GetValues().extent(1) + 1);
 		Kokkos::deep_copy(parametric_coords, -1.0);
 
-		tree->get_tree<3>()->query(
+		tree->get_tree<3>().query(
 			execution_space, 
 			detail::Coordinate_View_Adapt<MemorySpace, DIM>{coords.GetValues()},
 			detail::CallOnIntersect3D(
-				*tree->get_mappings<3>(),
+				tree->get_mappings<3>(),
 				mesh_.get_adj(Omega_h::REGION, 0).ab2b,
 				mesh_.get_adj(Omega_h::REGION, 1).ab2b,
 				mesh_.get_adj(Omega_h::REGION, 2).ab2b,
@@ -389,6 +392,28 @@ TreePointSearch::Results TreePointSearch::apply(
 			));
 		return Results{dims, elem_ids, parametric_coords};
 	}
+}
+
+[[nodiscard]] LO TreePointSearch::GetOwningElementId(
+	const TreePointSearch::Results& results, int i)
+{
+	return pcms::GetOwningElementId(mesh_, mesh_.dim(), (int)results.dimensionalities(i),
+		results.element_ids(i));
+}
+
+[[nodiscard]] Kokkos::View<LO*> TreePointSearch::GetOwningElementIds(
+	const TreePointSearch::Results& results)
+{
+	ExecSpace execution_space;
+	Kokkos::View<LO*> owning_ids("Owning element IDs", 
+		results.dimensionalities.size());
+	auto owning_ids_h = Kokkos::create_mirror_view(owning_ids);
+	for (int i = 0; i < owning_ids_h.size(); i++)
+	{
+		owning_ids_h[i] = GetOwningElementId(results, i);
+	}
+	Kokkos::deep_copy(execution_space, owning_ids, owning_ids_h);
+	return owning_ids;
 }
 
 std::unique_ptr<detail::TreeWrapper> TreePointSearch::make_tree(const Omega_h::Mesh& mesh) const
@@ -423,7 +448,7 @@ std::unique_ptr<detail::TreeWrapper> TreePointSearch::make_tree(const Omega_h::M
 				{vert_coords[face2vert[i*3]*2], vert_coords[face2vert[i*3]*2 + 1]},
 				{vert_coords[face2vert[i*3 + 1]*2], vert_coords[face2vert[i*3 + 1]*2 + 1]},
 				{vert_coords[face2vert[i*3 + 2]*2], vert_coords[face2vert[i*3 + 2]*2 + 1]}};
-			mappings_h[i] = detail::Mapping<2>(triangle);
+			mappings_h[i] = detail::Mapping<2>(triangle, tolerances_);
 		}
 		Kokkos::deep_copy(execution_space, mappings, mappings_h);
 		return std::make_unique<detail::TreeWrapper>(mappings, tree);
@@ -454,7 +479,7 @@ std::unique_ptr<detail::TreeWrapper> TreePointSearch::make_tree(const Omega_h::M
 				{vert_coords[region2vert[i*4 + 1]*3], vert_coords[region2vert[i*4 + 1]*3 + 1], vert_coords[region2vert[i*4 + 1]*3 + 2]},
 				{vert_coords[region2vert[i*4 + 2]*3], vert_coords[region2vert[i*4 + 2]*3 + 1], vert_coords[region2vert[i*4 + 2]*3 + 2]},
 				{vert_coords[region2vert[i*4 + 3]*3], vert_coords[region2vert[i*4 + 3]*3 + 1], vert_coords[region2vert[i*4 + 3]*3 + 2]}};
-			mappings_h[i] = detail::Mapping<3>(tetrahedron);
+			mappings_h[i] = detail::Mapping<3>(tetrahedron, tolerances_);
 		}
 		Kokkos::deep_copy(execution_space, mappings, mappings_h);
 		return std::make_unique<detail::TreeWrapper>(mappings, tree);

--- a/src/pcms/localization/point_localization.cpp
+++ b/src/pcms/localization/point_localization.cpp
@@ -63,7 +63,11 @@ Mapping<2>::Mapping(
 	const Kokkos::View<Real*>& tolerances)
 	: triangle(triangle_)
 {
-	tolerances_ = tolerances;
+	auto tol_h = Kokkos::create_mirror_view(tolerances);
+	Kokkos::deep_copy(tol_h, tolerances);
+	tolerances_[0] = tol_h(0);
+	tolerances_[1] = tol_h(1);
+	// printf("%d (%lf, %lf)\n", tol_h.size(), tolerances_[0], tolerances_[1]);
 	bary_transform = { triangle[0] - triangle[2], triangle[1] - triangle[2] };
 	triangle_area = 0.5*fabs(Omega_h::determinant(bary_transform));
 	bary_transform = Omega_h::invert(bary_transform);
@@ -100,7 +104,7 @@ int Mapping<2>::which_vert(Omega_h::Vector<Mapping<2>::DIM + 1> const& bary_coor
 		Omega_h::Vector<2> error = (bary_coords[0] - kronecker(i,0)) * triangle[0] 
 									+ (bary_coords[1] - kronecker(i,1)) * triangle[1] 
 									+ (bary_coords[2] - kronecker(i,2)) * triangle[2];
-		if (Omega_h::norm_squared(error) <= tolerances_(0)*tolerances_(0)) return i;
+		if (Omega_h::norm_squared(error) <= tolerances_[0]*tolerances_[0]) return i;
 	}
 	return -1;
 }
@@ -113,7 +117,7 @@ int Mapping<2>::which_edge(Omega_h::Vector<Mapping<2>::DIM + 1> const& bary_coor
 		// see docs for derivation.
 		double dist = (2*bary_coords[i]*triangle_area)*(2*bary_coords[i]*triangle_area);
 		dist /= opposite_edge_len_sq(i);
-		if (dist <= tolerances_(1)*tolerances_(1) &&
+		if (dist <= tolerances_[1]*tolerances_[1] &&
 			bary_coords[(i+1)%3] >= 0 && bary_coords[(i+2)%3] >= 0) return (i+1)%3;
 	}
 	return -1;
@@ -134,7 +138,11 @@ Mapping<3>::Mapping(
 	const Kokkos::View<Real*>& tolerances)
 	: tetrahedron(tetrahedron_)
 {
-	tolerances_ = tolerances;
+	auto tol_h = Kokkos::create_mirror_view(tolerances);
+	Kokkos::deep_copy(tol_h, tolerances);
+	tolerances_[0] = tol_h(0);
+	tolerances_[1] = tol_h(1);
+	tolerances_[2] = tol_h(2);
 	set_triangle_areas();
 	bary_transform = { tetrahedron[0] - tetrahedron[3], tetrahedron[1] - tetrahedron[3], tetrahedron[2] - tetrahedron[3] };
 	tetrahedron_volume = fabs(Omega_h::determinant(bary_transform))/6.;
@@ -174,7 +182,7 @@ int Mapping<3>::which_vert(Omega_h::Vector<Mapping<3>::DIM + 1> const& bary_coor
 		// distance to the ith vertex
 		Omega_h::Vector<3> error = (bary_coords[0] - kronecker(i,0)) * tetrahedron[0] + (bary_coords[1] - kronecker(i,1)) * tetrahedron[1]
 									+ (bary_coords[2] - kronecker(i,2)) * tetrahedron[2] + (bary_coords[3] - kronecker(i,3)) * tetrahedron[3];
-		if (Omega_h::norm_squared(error) <= tolerances_(0)*tolerances_(0)) return i;
+		if (Omega_h::norm_squared(error) <= tolerances_[0]*tolerances_[0]) return i;
 	}
 	return -1;
 }
@@ -199,7 +207,7 @@ int Mapping<3>::which_edge(Omega_h::Vector<Mapping<3>::DIM + 1> const& bary_coor
 			double distnce_sq = Omega_h::norm_squared(Omega_h::cross(side1, side2));
 			distnce_sq /= Omega_h::norm_squared(side3);
 			
-			if (distnce_sq <= tolerances_(1)*tolerances_(1) && bary_coords[i] > 0 && bary_coords[j] > 0) return edge(edge_);
+			if (distnce_sq <= tolerances_[1]*tolerances_[1] && bary_coords[i] > 0 && bary_coords[j] > 0) return edge(edge_);
 			edge_++;
 		}
 	}
@@ -210,7 +218,7 @@ int Mapping<3>::which_face(Omega_h::Vector<Mapping<3>::DIM + 1> const& bary_coor
 {
 	for (int i = 0; i < 4; i++)
 	{
-		if (fabs(3*tetrahedron_volume*bary_coords[i]/face_areas[i]) <= tolerances_(2)
+		if (fabs(3*tetrahedron_volume*bary_coords[i]/face_areas[i]) <= tolerances_[2]
 			&& bary_coords[(i+1)%4] >= 0 && bary_coords[(i+2)%4] >= 0 && bary_coords[(i+3)%4] >= 0)
 		{
 			return face(i);
@@ -479,6 +487,9 @@ std::unique_ptr<detail::TreeWrapper> TreePointSearch::make_tree(const Omega_h::M
 				{vert_coords[region2vert[i*4 + 1]*3], vert_coords[region2vert[i*4 + 1]*3 + 1], vert_coords[region2vert[i*4 + 1]*3 + 2]},
 				{vert_coords[region2vert[i*4 + 2]*3], vert_coords[region2vert[i*4 + 2]*3 + 1], vert_coords[region2vert[i*4 + 2]*3 + 2]},
 				{vert_coords[region2vert[i*4 + 3]*3], vert_coords[region2vert[i*4 + 3]*3 + 1], vert_coords[region2vert[i*4 + 3]*3 + 2]}};
+
+			auto tol_h = Kokkos::create_mirror_view(tolerances_);
+			Kokkos::deep_copy(tol_h, tolerances_);
 			mappings_h[i] = detail::Mapping<3>(tetrahedron, tolerances_);
 		}
 		Kokkos::deep_copy(execution_space, mappings, mappings_h);

--- a/src/pcms/localization/point_localization.cpp
+++ b/src/pcms/localization/point_localization.cpp
@@ -4,39 +4,31 @@
 #define EDGE_TOL 10e-6
 #define VERT_TOL 10e-5
 
-#define kronecker(i,j) (int)(i==j)
-
-// adds template parameters required by ArborX Access traits
-template <typename DeviceType, int dim, class coord = float>
-struct Omega_h_Mesh_Tagged
-{
-	const Omega_h::Mesh & m;
-};
-
 // Access traits for Omega_h
 // constructs bounding boxes for elements
-template <typename DeviceType, int dim, class coord>
-struct ArborX::AccessTraits<Omega_h_Mesh_Tagged<DeviceType, dim, coord>>
+template <int dim>
+struct ArborX::AccessTraits<pcms::detail::Omega_h_Mesh_Adapt<dim>>
 {
-	using memory_space = typename DeviceType::memory_space;
+	using memory_space = typename Omega_h::ExecSpace::memory_space;
 
-	static KOKKOS_FUNCTION int size(const Omega_h_Mesh_Tagged<DeviceType, dim, coord>& mesh)
+	static KOKKOS_FUNCTION int size(
+		const pcms::detail::Omega_h_Mesh_Adapt<dim>& mesh)
 	{
-		return mesh.m.nelems();
+		return mesh.size_;
 	}
 
-	static KOKKOS_FUNCTION auto get(const Omega_h_Mesh_Tagged<DeviceType, dim, coord>& mesh, int i)
+	static KOKKOS_FUNCTION auto get(
+		const pcms::detail::Omega_h_Mesh_Adapt<dim>& mesh, 
+		int i)
 	{
-		const auto face2verts = mesh.m.get_adj(dim, Omega_h::VERT).ab2b;
-		const auto vert_coords = mesh.m.coords();
-		ArborX::Point<dim, coord> min = {INFINITY};
-		ArborX::Point<dim, coord> max = {-INFINITY};
+		ArborX::Point<dim, Omega_h::Real> min = {INFINITY};
+		ArborX::Point<dim, Omega_h::Real> max = {-INFINITY};
 		for (int j = 0; j < dim + 1; ++j)
 		{
-			auto cell_vert_id = face2verts[(dim+1)*i+j];
+			auto cell_vert_id = mesh.adjacency[(dim+1)*i+j];
 			for (int k = 0; k < dim; ++k)
 			{
-				coord curr_coord = vert_coords[cell_vert_id*dim+k];
+				Omega_h::Real curr_coord = mesh.coordinates[cell_vert_id*dim+k];
 				if (min[k] > curr_coord) min[k] = curr_coord;
 				if (max[k] < curr_coord) max[k] = curr_coord;
 			}
@@ -45,29 +37,21 @@ struct ArborX::AccessTraits<Omega_h_Mesh_Tagged<DeviceType, dim, coord>>
 	}
 };
 
-// adds template parameters required by ArborX Access traits
 template <typename MemorySpace, int dim>
-struct pcms_Coordinate_View_Tagged
-{
-	const pcms::CoordinateView<MemorySpace>& cv;
-};
-
-template <typename MemorySpace, int DIM>
-struct ArborX::AccessTraits<pcms_Coordinate_View_Tagged<MemorySpace, DIM>>
+struct ArborX::AccessTraits<pcms::detail::Coordinate_View_Adapt<MemorySpace, dim>>
 {
 	using memory_space = MemorySpace;
-	static KOKKOS_FUNCTION int size(pcms_Coordinate_View_Tagged<MemorySpace, DIM> const &coords)
+	static KOKKOS_FUNCTION int size(
+		pcms::detail::Coordinate_View_Adapt<MemorySpace, dim> const &coords)
 	{
-		return coords.cv.GetCoordinates().extent(0);
+		return coords.points.extent(0);
 	}
 	static KOKKOS_FUNCTION auto get(
-		pcms_Coordinate_View_Tagged<MemorySpace, DIM> const &coords, 
+		pcms::detail::Coordinate_View_Adapt<MemorySpace, dim> const &coords, 
 		int i)
 	{
-		const auto points = coords.cv.GetCoordinates();
-		constexpr int dim = DIM;
 		ArborX::Point<dim, double> ax_point;
-		for (int j = 0; j < dim; j++) ax_point[j] = points(i,j);
+		for (int j = 0; j < dim; j++) ax_point[j] = coords.points(i,j);
 		return PredicateWithAttachment(intersects(ax_point), i);
 	}
 };
@@ -75,11 +59,9 @@ struct ArborX::AccessTraits<pcms_Coordinate_View_Tagged<MemorySpace, DIM>>
 namespace pcms
 {
 
-/**
-* @brief Constructs a barycentric mapping of a triangle in an Omega_h::Mesh
-* @param elem_index the index of the desired triangle or tetrahedron in the Omega_h::Mesh
-* @param mesh the Omega_h::Mesh with the spatial information of the triangle
-*/
+namespace detail
+{
+
 Mapping2D::Mapping2D(int elem_index, Omega_h::Mesh const& mesh)
 {
 	set_mesh_triangle(elem_index, mesh);
@@ -88,12 +70,6 @@ Mapping2D::Mapping2D(int elem_index, Omega_h::Mesh const& mesh)
 	bary_transform = Omega_h::invert(bary_transform);
 }
 
-/**
-* @brief Computes the barycentric coordinates of a point in global space
-* @param p the point to compute the barycentric coordinates of
-* @returns an Omega_h::Vector<dim + 1> containing the barycentric coordinates
-* 			of p
-*/
 KOKKOS_FUNCTION
 Omega_h::Vector<Mapping2D::DIM + 1> Mapping2D::get_bary(Omega_h::Vector<Mapping2D::DIM> const& p) const
 {
@@ -117,14 +93,6 @@ int Mapping2D::which(int dim,
 	return -1;
 }
 
-/**
-* @brief Computes the vertex offset of the point corresponding 
-* 		  to the input barycentric coordinates
-* @param bary_coords the input barycentric coordinates
-* @returns the vertex offset if the point corresponding to the given bary. coordinates
-* 			is within a certain (global) tolerance of a vertex
-* 			-1 if the point does not lie within the tolerance of any vertex
-*/
 int Mapping2D::which_vert(Omega_h::Vector<Mapping2D::DIM + 1> const& bary_coords) const
 {
 	for (int i = 0; i < 3; i++)
@@ -138,15 +106,6 @@ int Mapping2D::which_vert(Omega_h::Vector<Mapping2D::DIM + 1> const& bary_coords
 	return -1;
 }
 
-/**
-* @brief Computes the edge offset of the point corresponding 
-* 		 to the input barycentric coordinates
-* @param bary_coords the input barycentric coordinates
-* @returns the edge offset if the distnce from the point corresponding to the 
-* 			given bary. coordinates to the edge with the respective offset
-* 			is within a certain (global) tolerance
-* 			-1 if the point does not lie within the tolerance of any vertex
-*/
 int Mapping2D::which_edge(Omega_h::Vector<Mapping2D::DIM + 1> const& bary_coords) const
 {
 	for (int i = 0; i <= 2; i++)
@@ -161,47 +120,25 @@ int Mapping2D::which_edge(Omega_h::Vector<Mapping2D::DIM + 1> const& bary_coords
 	return -1;
 }
 
-/**
-* @brief Computes whether a point with the given barycentric coordinates
-* 		  is within a triangle
-* @param bary_coords the input barycentric coordinates
-* @returns 0 if the point is within the highest order element and -1 otherwise
-*/
 int Mapping2D::within_elem(Omega_h::Vector<Mapping2D::DIM + 1> const& bary_coords) const
 {
 	return -1 * (int)!(bary_coords[0] > 0 && bary_coords[1] > 0 && bary_coords[2] > 0);
 }
 
-/**
-* @brief Constructs the triangle the mapping is for
-* @param index the element ID of the triangle
-* @param mesh the Omega_h::Mesh with the spatial information for the triangle
-* 			   corresponding to index
-*/
 void Mapping2D::set_mesh_triangle(int index, Omega_h::Mesh const& mesh)
 {
-	auto face2vert = mesh.get_adj(Omega_h::FACE, Omega_h::VERT).ab2b;
-	auto vert_coords = mesh.coords();
+	auto face2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::FACE, Omega_h::VERT).ab2b);
+	auto vert_coords = Omega_h::HostRead(mesh.coords());
 	triangle = Omega_h::Matrix<2,3>{{vert_coords[face2vert[index*3]*2], vert_coords[face2vert[index*3]*2 + 1]},
 			{vert_coords[face2vert[index*3 + 1]*2], vert_coords[face2vert[index*3 + 1]*2 + 1]},
 			{vert_coords[face2vert[index*3 + 2]*2], vert_coords[face2vert[index*3 + 2]*2 + 1]}};
 }
 
-/**
-* @brief Calculates the length of the edge opposite vertex i
-* @param i the vertex index opposite the desired edge
-* @returns the length of the ith edge
-*/
 double Mapping2D::opposite_edge_len_sq(int i) const
 {
 	return Omega_h::norm_squared(triangle[(i+2)%3] - triangle[(i+1)%3]);
 }
 
-/**
-* @brief Constructs a barycentric mapping of a triangle in an Omega_h::Mesh
-* @param elem_index the index of the desired triangle or tetrahedron in the Omega_h::Mesh
-* @param mesh the Omega_h::Mesh with the spatial information of the triangle
-*/
 Mapping3D::Mapping3D(int elem_index, Omega_h::Mesh const& mesh)
 {
 	set_mesh_tet(elem_index, mesh);
@@ -211,12 +148,6 @@ Mapping3D::Mapping3D(int elem_index, Omega_h::Mesh const& mesh)
 	bary_transform = Omega_h::invert(bary_transform);
 }
 
-/**
-* @brief Computes the barycentric coordinates of a point in global space
-* @param p the point to compute the barycentric coordinates of
-* @returns an Omega_h::Vector<dim + 1> containing the barycentric coordinates
-* 			of p
-*/
 KOKKOS_FUNCTION
 Omega_h::Vector<Mapping3D::DIM + 1> Mapping3D::get_bary(Omega_h::Vector<Mapping3D::DIM> const& p) const
 {
@@ -243,14 +174,6 @@ int Mapping3D::which(int dim,
 	return -1;
 }
 
-/**
-* @brief Computes the vertex offset of the point corresponding 
-		to the input barycentric coordinates
-* @param bary_coords the input barycentric coordinates
-* @returns the vertex offset if the point corresponding to the given bary. coordinates
-* 			is within a certain (global) tolerance of a vertex
-* 			-1 if the point does not lie within the tolerance of any vertex
-*/
 int Mapping3D::which_vert(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords) const
 {
 	for (int i = 0; i < 4; i++)
@@ -263,15 +186,7 @@ int Mapping3D::which_vert(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords
 	return -1;
 }
 
-/**
-* @brief Computes the edge offset of the point corresponding 
-* 		 to the input barycentric coordinates
-* @param bary_coords the input barycentric coordinates
-* @returns the edge offset if the distnce from the point corresponding to the 
-* 			given bary. coordinates to the edge with the respective offset
-* 			is within a certain (global) tolerance
-* 			-1 if the point does not lie within the tolerance of any vertex
-*/
+
 int Mapping3D::which_edge(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords) const
 {
 	int edge_ = 0;
@@ -298,20 +213,6 @@ int Mapping3D::which_edge(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords
 	return -1;
 }
 
-/**
-* @brief Computes the face offset of the point corresponding 
-* 		 to the input barycentric coordinates
-* @param bary_coords the input barycentric coordinates
-* @returns if the point corresponding to the bary. coords is within a 
-* 			global tolerance of a face, returns the offset of that face
-* 			-1 if the point does not lie within the tolerance of any face
-* Algorithm source:
-* C.E. Passerello,
-* Interference detection using barycentric coordinates,
-* Mechanics Research Communications,
-* Volume 9, Issue 6, 1982, Pages 373-378,
-* https://doi.org/10.1016/0093-6413(82)90034-9.
-*/
 int Mapping3D::which_face(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords) const
 {
 	for (int i = 0; i < 4; i++)
@@ -324,23 +225,16 @@ int Mapping3D::which_face(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords
 	}
 	return -1;
 }
-	
-/**
-* @brief Computes whether a point with the given barycentric coordinates
-* 		  is within a triangle
-* @param bary_coords the input barycentric coordinates
-* @returns 0 if the point is within the highet order element and -1 otherwise
-*/
+
 int Mapping3D::within_elem(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords) const
 {
 	return -1 * (int)!(bary_coords[0] >= 0 && bary_coords[1] >= 0 && bary_coords[2] >= 0 && bary_coords[3] >= 0);
 }
 
-// constructs the tetrahedron from the mesh's spatial data
 void Mapping3D::set_mesh_tet(int index, Omega_h::Mesh const& mesh)
 {
-	auto region2vert = mesh.get_adj(Omega_h::REGION, Omega_h::VERT).ab2b;
-	auto vert_coords = mesh.coords();
+	auto region2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::REGION, Omega_h::VERT).ab2b);
+	auto vert_coords = Omega_h::HostRead(mesh.coords());
 	tetrahedron = {{vert_coords[region2vert[index*4]*3], vert_coords[region2vert[index*4]*3 + 1], vert_coords[region2vert[index*4]*3 + 2]},
 	{vert_coords[region2vert[index*4 + 1]*3], vert_coords[region2vert[index*4 + 1]*3 + 1], vert_coords[region2vert[index*4 + 1]*3 + 2]},
 	{vert_coords[region2vert[index*4 + 2]*3], vert_coords[region2vert[index*4 + 2]*3 + 1], vert_coords[region2vert[index*4 + 2]*3 + 2]},
@@ -360,15 +254,10 @@ void Mapping3D::set_triangle_areas()
 	}
 }
 
-TreePointSearch::TreePointSearch(const Omega_h::Mesh& mesh) : 
-	mesh_(mesh), 
-	tree(make_tree(mesh))
-{
-	
-}
+} //namespace detail
 
-Kokkos::View<PointSearch::Result*> TreePointSearch::apply(
-	const CoordinateView<Omega_h::ExecSpace::memory_space>& coords) const
+Kokkos::View<TreePointSearch::Result*> TreePointSearch::apply(
+	const CoordinateView<TreePointSearch::MemorySpace>& coords) const
 {
 	if (coords.GetCoordinateSystem() != pcms::CoordinateSystem::Cartesian)
 	{
@@ -398,46 +287,16 @@ Kokkos::View<PointSearch::Result*> TreePointSearch::apply(
 			results_h[i].parametric_coords = {-1, -1, -1, -1};
 		}
 		Kokkos::deep_copy(execution_space, intersection_results, results_h);
-	
-		auto CallOnIntersect = KOKKOS_LAMBDA <typename Predicate, typename Value>
-		(Predicate const &predicate, Value const & val)
-		{
-			ArborX::Point<DIM, Omega_h::Real> const& ax = ArborX::getGeometry(predicate);
-			Omega_h::Vector<DIM> point{ax[0], ax[1]};
-			int point_ind = ArborX::getData(predicate);
-			
-			Mapping2D const& tm = get_mapping2D(val.index);
-			
-			// calculate the barycentric coefficients of the point
-			auto coeffs = tm.get_bary(point);
-	
-			for (int i = 0; i < DIM; i++)
-			{
-				int elem = tm.which(i, coeffs);
-				if (elem >= 0 && intersection_results(point_ind).dimensionality > (Dimensionality)i)
-				{
-					auto face2elem = mesh_.get_adj(Omega_h::FACE, i).ab2b;
-					auto elem_ind = face2elem[3*val.index + elem];
-					intersection_results(point_ind).dimensionality = (Dimensionality)i;
-					intersection_results(point_ind).element_id = elem_ind;
-					for (int j = 0; j < DIM + 1; j++)
-						intersection_results(point_ind).parametric_coords(j) = coeffs[j];
-					return;
-				}
-			}
-			if (tm.which(DIM, coeffs) >= 0 
-				&& intersection_results(point_ind).dimensionality > Dimensionality::FACE)
-			{
-				intersection_results(point_ind).dimensionality = Dimensionality::FACE;
-				intersection_results(point_ind).element_id = (LO)val.index;
-				for (int j = 0; j < DIM + 1; j++)
-						intersection_results(point_ind).parametric_coords(j) = coeffs[j];
-			}
-		};
-	
-		((TreeWrapper2D::Tree_t*)tree->get_tree())->query(execution_space, 
-				   pcms_Coordinate_View_Tagged<Omega_h::ExecSpace::memory_space, DIM>{coords},
-				   CallOnIntersect);
+
+		((detail::TreeWrapper2D::Tree_t*)tree->get_tree())->query(execution_space, 
+					detail::Coordinate_View_Adapt<MemorySpace, DIM>{
+					coords.GetCoordinates()},
+					detail::CallOnIntersect2D(
+						*(detail::TreeWrapper2D::Mappings_t*)tree->get_mappings(),
+						mesh_.get_adj(Omega_h::FACE, 0).ab2b,
+						mesh_.get_adj(Omega_h::FACE, 1).ab2b,
+						intersection_results
+					));
 		return intersection_results;
 	}
 	else
@@ -456,84 +315,80 @@ Kokkos::View<PointSearch::Result*> TreePointSearch::apply(
 		}
 		Kokkos::deep_copy(execution_space, intersection_results, results_h);
 		
-		auto CallOnIntersect = KOKKOS_LAMBDA <typename Predicate, typename Value>
-		(Predicate const &predicate, Value const & val)
-		{
-			ArborX::Point<DIM, Omega_h::Real> const& ax = ArborX::getGeometry(predicate);
-			Omega_h::Vector<DIM> point{ax[0], ax[1], ax[2]};
-			int point_ind = ArborX::getData(predicate);
-			
-			Mapping3D const& tm = get_mapping3D(val.index);
-			
-			// calculate the barycentric coefficients of the point
-			auto coeffs = tm.get_bary(point);
-			int offsets[DIM] = {4, 6, 4};
-			for (int i = 0; i < DIM; i++)
-			{
-				int elem = tm.which(i, coeffs);
-				if (elem >= 0 && intersection_results(point_ind).dimensionality > (Dimensionality)i)
-				{
-					auto face2elem = mesh_.get_adj(Omega_h::REGION, i).ab2b;
-					auto elem_ind = face2elem[offsets[i]*val.index + elem];
-					intersection_results(point_ind).dimensionality = (Dimensionality)i;
-					intersection_results(point_ind).element_id = elem_ind;
-					for (int j = 0; j < DIM + 1; j++)
-						intersection_results(point_ind).parametric_coords(j) = coeffs[j];
-					return;
-				}
-			}
-
-			if (tm.which(DIM, coeffs) >= 0 
-					&& intersection_results(point_ind).dimensionality >= Dimensionality::REGION)
-			{
-				intersection_results(point_ind).dimensionality = Dimensionality::REGION;
-				intersection_results(point_ind).element_id = (LO)val.index;
-				for (int j = 0; j < DIM + 1; j++)
-						intersection_results(point_ind).parametric_coords(j) = coeffs[j];
-			}
+		detail::TreeWrapper3D::Mappings_t mappings = *(detail::TreeWrapper3D::Mappings_t*)tree->get_mappings();
+		Omega_h::LOs adjacencies[3] = {
+			mesh_.get_adj(Omega_h::REGION, 0).ab2b,
+			mesh_.get_adj(Omega_h::REGION, 1).ab2b,
+			mesh_.get_adj(Omega_h::REGION, 2).ab2b
 		};
 
-		((TreeWrapper3D::Tree_t*)tree->get_tree())->query(execution_space, 
-				   pcms_Coordinate_View_Tagged<Omega_h::ExecSpace::memory_space, DIM>{coords},
-				   CallOnIntersect);
+		((detail::TreeWrapper3D::Tree_t*)tree->get_tree())->query(execution_space, 
+			detail::Coordinate_View_Adapt<MemorySpace, 
+			DIM>{
+			coords.GetCoordinates()},
+			detail::CallOnIntersect3D(
+				*(detail::TreeWrapper3D::Mappings_t*)tree->get_mappings(),
+				mesh_.get_adj(Omega_h::REGION, 0).ab2b,
+				mesh_.get_adj(Omega_h::REGION, 1).ab2b,
+				mesh_.get_adj(Omega_h::REGION, 2).ab2b,
+				intersection_results	
+			));
 		return intersection_results;
 	}
 }
 
-std::unique_ptr<TreeWrapper> TreePointSearch::make_tree(const Omega_h::Mesh& mesh) const
+std::unique_ptr<detail::TreeWrapper> TreePointSearch::make_tree(const Omega_h::Mesh& mesh) const
 {
 	ExecSpace execution_space;
 	using DeviceType = Kokkos::Device<Omega_h::ExecSpace, 
 									  Omega_h::ExecSpace::memory_space>;
+	
 	if (mesh.dim() == 2)
 	{
-		Omega_h_Mesh_Tagged<DeviceType, 2, double> tagged_mesh{mesh};
-		TreeWrapper2D::Tree_t tree = ArborX::BVH(execution_space, 
-							ArborX::Experimental::attach_indices(tagged_mesh));
-	
-		TreeWrapper2D::Mappings_t mappings = Kokkos::View<Mapping2D*, Omega_h::ExecSpace::memory_space>("mappings", mesh.nelems());
+		detail::Omega_h_Mesh_Adapt<2> tagged_mesh{
+			mesh.nelems(),
+			mesh.get_adj(Omega_h::FACE, Omega_h::VERT).ab2b,
+			mesh.coords()
+		};
+		
+		detail::TreeWrapper2D::Tree_t tree = detail::TreeWrapper2D::Tree_t(
+			execution_space,
+			ArborX::Experimental::attach_indices(tagged_mesh));
+			
+		detail::TreeWrapper2D::Mappings_t mappings = detail::TreeWrapper2D::Mappings_t(
+			"mappings", 
+			mesh.nelems());
+		
 		auto mappings_h = Kokkos::create_mirror_view(mappings);
 		for (int i = 0; i < mesh.nelems(); i++)
 		{
-			mappings_h[i] = Mapping2D(i, mesh);
+			mappings_h[i] = detail::Mapping2D(i, mesh);
 		}
 		Kokkos::deep_copy(execution_space, mappings, mappings_h);
-		return std::make_unique<TreeWrapper2D>(mappings, tree);
+		return std::make_unique<detail::TreeWrapper2D>(mappings, tree);
 	}
 	if (mesh.dim() == 3)
 	{
-		Omega_h_Mesh_Tagged<DeviceType, 3, double> tagged_mesh{mesh};
-		TreeWrapper3D::Tree_t tree = ArborX::BVH(execution_space, 
-							ArborX::Experimental::attach_indices(tagged_mesh));
+		detail::Omega_h_Mesh_Adapt<3> tagged_mesh{
+			mesh.nelems(),
+			mesh.get_adj(Omega_h::REGION, Omega_h::VERT).ab2b,
+			mesh.coords()
+		};
+		detail::TreeWrapper3D::Tree_t tree = detail::TreeWrapper3D::Tree_t(
+			execution_space, 
+			ArborX::Experimental::attach_indices(tagged_mesh));
 	
-		TreeWrapper3D::Mappings_t mappings = Kokkos::View<Mapping3D*, Omega_h::ExecSpace::memory_space>("mappings", mesh.nelems());
+		detail::TreeWrapper3D::Mappings_t mappings = detail::TreeWrapper3D::Mappings_t(
+			"mappings", 
+			mesh.nelems());
+		
 		auto mappings_h = Kokkos::create_mirror_view(mappings);
 		for (int i = 0; i < mesh.nelems(); i++)
 		{
-			mappings_h[i] = Mapping3D(i, mesh);
+			mappings_h[i] = detail::Mapping3D(i, mesh);
 		}
 		Kokkos::deep_copy(execution_space, mappings, mappings_h);
-		return std::make_unique<TreeWrapper3D>(mappings, tree);
+		return std::make_unique<detail::TreeWrapper3D>(mappings, tree);
 	}
 	throw pcms_error("Invalid mesh dimension " + std::to_string(mesh.dim()) + ", TreePointSearch only implemented for 2D and 3D");
 }

--- a/src/pcms/localization/point_localization.cpp
+++ b/src/pcms/localization/point_localization.cpp
@@ -89,11 +89,11 @@ Mapping2D::Mapping2D(int elem_index, Omega_h::Mesh const& mesh)
 }
 
 /**
-	* @brief Computes the barycentric coordinates of a point in global space
-	* @param p the point to compute the barycentric coordinates of
-	* @returns an Omega_h::Vector<dim + 1> containing the barycentric coordinates
-	* 			of p
-	*/
+* @brief Computes the barycentric coordinates of a point in global space
+* @param p the point to compute the barycentric coordinates of
+* @returns an Omega_h::Vector<dim + 1> containing the barycentric coordinates
+* 			of p
+*/
 KOKKOS_FUNCTION
 Omega_h::Vector<Mapping2D::DIM + 1> Mapping2D::get_bary(Omega_h::Vector<Mapping2D::DIM> const& p) const
 {
@@ -101,6 +101,7 @@ Omega_h::Vector<Mapping2D::DIM + 1> Mapping2D::get_bary(Omega_h::Vector<Mapping2
 	return {coeffs[0], coeffs[1], 1 - coeffs[0] - coeffs[1]};
 }
 
+KOKKOS_FUNCTION
 int Mapping2D::which(int dim, 
 					 Omega_h::Vector<Mapping2D::DIM + 1> const& bary_coords) const
 {
@@ -117,13 +118,13 @@ int Mapping2D::which(int dim,
 }
 
 /**
-	* @brief Computes the vertex offset of the point corresponding 
-	* 		  to the input barycentric coordinates
-	* @param bary_coords the input barycentric coordinates
-	* @returns the vertex offset if the point corresponding to the given bary. coordinates
-	* 			is within a certain (global) tolerance of a vertex
-	* 			-1 if the point does not lie within the tolerance of any vertex
-	*/
+* @brief Computes the vertex offset of the point corresponding 
+* 		  to the input barycentric coordinates
+* @param bary_coords the input barycentric coordinates
+* @returns the vertex offset if the point corresponding to the given bary. coordinates
+* 			is within a certain (global) tolerance of a vertex
+* 			-1 if the point does not lie within the tolerance of any vertex
+*/
 int Mapping2D::which_vert(Omega_h::Vector<Mapping2D::DIM + 1> const& bary_coords) const
 {
 	for (int i = 0; i < 3; i++)
@@ -216,12 +217,14 @@ Mapping3D::Mapping3D(int elem_index, Omega_h::Mesh const& mesh)
 * @returns an Omega_h::Vector<dim + 1> containing the barycentric coordinates
 * 			of p
 */
+KOKKOS_FUNCTION
 Omega_h::Vector<Mapping3D::DIM + 1> Mapping3D::get_bary(Omega_h::Vector<Mapping3D::DIM> const& p) const
 {
 	Omega_h::Vector<3> coeffs = bary_transform*(p - tetrahedron[3]);
 	return {coeffs[0], coeffs[1], coeffs[2], 1 - coeffs[0] - coeffs[1] - coeffs[2]};
 }
 
+KOKKOS_FUNCTION
 int Mapping3D::which(int dim, 
 					 Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords) const
 {
@@ -357,183 +360,182 @@ void Mapping3D::set_triangle_areas()
 	}
 }
 
-TreePointSearch2D::TreePointSearch2D(const Omega_h::Mesh& mesh) : mesh_(mesh)
+TreePointSearch::TreePointSearch(const Omega_h::Mesh& mesh) : 
+	mesh_(mesh), 
+	tree(make_tree(mesh))
 {
-	if (mesh.dim() != 2) 
-	{
-		throw pcms_error("Could not construct TreePointSearch2D, invalid mesh dimension");
-	}
-
-	Omega_h::ExecSpace execution_space;
-	using DeviceType = Kokkos::Device<Omega_h::ExecSpace, 
-									  Omega_h::ExecSpace::memory_space>;
-	Omega_h_Mesh_Tagged<DeviceType, 2, double> tagged_mesh{mesh};
-	tree = ArborX::BVH(execution_space, 
-						ArborX::Experimental::attach_indices(tagged_mesh));
-
-	mappings = Kokkos::View<Mapping2D*, Omega_h::ExecSpace::memory_space>("mappings", mesh.nelems());
-	auto mappings_h = Kokkos::create_mirror_view(mappings);
-	for (int i = 0; i < mesh.nelems(); i++)
-	{
-		mappings_h[i] = Mapping2D(i, mesh);
-	}
-	Kokkos::deep_copy(execution_space, mappings, mappings_h);
+	
 }
 
-Kokkos::View<PointSearch2D::Result*> TreePointSearch2D::apply(
+Kokkos::View<PointSearch::Result*> TreePointSearch::apply(
 	const CoordinateView<Omega_h::ExecSpace::memory_space>& coords) const
 {
 	if (coords.GetCoordinateSystem() != pcms::CoordinateSystem::Cartesian)
 	{
-		throw pcms_error("TreePointSearch2D::apply only implemented for"
+		throw pcms_error("TreePointSearch::apply only implemented for"
 						 " Cartesian coordinates");
 	}
-	
-	Omega_h::ExecSpace execution_space;
-	Kokkos::View<PointSearch2D::Result*> intersection_results("2D intersection results",
-																coords.GetCoordinates().extent(0));
-	auto results_h = Kokkos::create_mirror_view(intersection_results);
-	for (int i = 0; i < intersection_results.size(); i++) 
-		results_h[i] = Result_t{
-			.dimensionality = Dim_t::REGION,
-			.element_id = -1,
-			.parametric_coords = {-1, -1, -1}
-		};
-	Kokkos::deep_copy(execution_space, intersection_results, results_h);
-
-	auto CallOnIntersect = KOKKOS_LAMBDA <typename Predicate, typename Value>
-	(Predicate const &predicate, Value const & val)
+	if (coords.GetCoordinates().extent(1) != mesh_.dim())
 	{
-		ArborX::Point<2, Omega_h::Real> const& ax = ArborX::getGeometry(predicate);
-		Omega_h::Vector<2> point{ax[0], ax[1]};
-		int point_ind = ArborX::getData(predicate);
-		
-		Mapping2D const& tm = mappings(val.index);
-		
-		// calculate the barycentric coefficients of the point
-		auto coeffs = tm.get_bary(point);
-
-		for (int i = 0; i < DIM; i++)
+		throw pcms_error("Input coordinate space dimension " 
+			+ std::to_string(coords.GetCoordinates().extent(1))
+			+ " does not match query space dimension " 
+			+ std::to_string(mesh_.dim()));
+	}
+	
+	if (mesh_.dim() == 2)
+	{
+		static constexpr int DIM = 2;
+		Omega_h::ExecSpace execution_space;
+		Kokkos::View<PointSearch::Result*, MemorySpace> 
+			intersection_results("2D intersection results",
+				coords.GetCoordinates().extent(0));
+		auto results_h = Kokkos::create_mirror_view(intersection_results);
+		for (int i = 0; i < intersection_results.size(); i++) 
 		{
-			int elem = tm.which(i, coeffs);
-			if (elem >= 0 && intersection_results(point_ind).dimensionality > (Dim_t)i)
+			results_h[i].dimensionality = Dimensionality::REGION,
+			results_h[i].element_id = -1,
+			results_h[i].parametric_coords = {-1, -1, -1, -1};
+		}
+		Kokkos::deep_copy(execution_space, intersection_results, results_h);
+	
+		auto CallOnIntersect = KOKKOS_LAMBDA <typename Predicate, typename Value>
+		(Predicate const &predicate, Value const & val)
+		{
+			ArborX::Point<DIM, Omega_h::Real> const& ax = ArborX::getGeometry(predicate);
+			Omega_h::Vector<DIM> point{ax[0], ax[1]};
+			int point_ind = ArborX::getData(predicate);
+			
+			Mapping2D const& tm = get_mapping2D(val.index);
+			
+			// calculate the barycentric coefficients of the point
+			auto coeffs = tm.get_bary(point);
+	
+			for (int i = 0; i < DIM; i++)
 			{
-				auto face2elem = mesh_.get_adj(Omega_h::FACE, i).ab2b;
-				auto elem_ind = face2elem[3*val.index + elem];
-				intersection_results(point_ind) = PointSearch2D::Result{
-					.dimensionality = (Dim_t)i, 
-					.element_id = elem_ind, 
-					.parametric_coords = coeffs
-				};
-				return;
+				int elem = tm.which(i, coeffs);
+				if (elem >= 0 && intersection_results(point_ind).dimensionality > (Dimensionality)i)
+				{
+					auto face2elem = mesh_.get_adj(Omega_h::FACE, i).ab2b;
+					auto elem_ind = face2elem[3*val.index + elem];
+					intersection_results(point_ind).dimensionality = (Dimensionality)i;
+					intersection_results(point_ind).element_id = elem_ind;
+					for (int j = 0; j < DIM + 1; j++)
+						intersection_results(point_ind).parametric_coords(j) = coeffs[j];
+					return;
+				}
 			}
-		}
-		if (tm.which(DIM, coeffs) >= 0 
-			&& intersection_results(point_ind).dimensionality > Dim_t::FACE)
+			if (tm.which(DIM, coeffs) >= 0 
+				&& intersection_results(point_ind).dimensionality > Dimensionality::FACE)
+			{
+				intersection_results(point_ind).dimensionality = Dimensionality::FACE;
+				intersection_results(point_ind).element_id = (LO)val.index;
+				for (int j = 0; j < DIM + 1; j++)
+						intersection_results(point_ind).parametric_coords(j) = coeffs[j];
+			}
+		};
+	
+		((TreeWrapper2D::Tree_t*)tree->get_tree())->query(execution_space, 
+				   pcms_Coordinate_View_Tagged<Omega_h::ExecSpace::memory_space, DIM>{coords},
+				   CallOnIntersect);
+		return intersection_results;
+	}
+	else
+	{
+		static constexpr int DIM = 3;
+		Omega_h::ExecSpace execution_space;
+		Kokkos::View<PointSearch::Result*, MemorySpace> 
+			intersection_results("3D intersection results",
+				coords.GetCoordinates().extent(0));
+		auto results_h = Kokkos::create_mirror_view(intersection_results);
+		for (int i = 0; i < intersection_results.size(); i++) 
 		{
-			intersection_results(point_ind) = PointSearch2D::Result{
-				.dimensionality = Dim_t::FACE,
-				.element_id = (LO)val.index,
-				.parametric_coords = coeffs
-			};
+			results_h[i].dimensionality = Dimensionality::REGION,
+			results_h[i].element_id = -1,
+			results_h[i].parametric_coords = {-1, -1, -1, -1};
 		}
-	};
+		Kokkos::deep_copy(execution_space, intersection_results, results_h);
+		
+		auto CallOnIntersect = KOKKOS_LAMBDA <typename Predicate, typename Value>
+		(Predicate const &predicate, Value const & val)
+		{
+			ArborX::Point<DIM, Omega_h::Real> const& ax = ArborX::getGeometry(predicate);
+			Omega_h::Vector<DIM> point{ax[0], ax[1], ax[2]};
+			int point_ind = ArborX::getData(predicate);
+			
+			Mapping3D const& tm = get_mapping3D(val.index);
+			
+			// calculate the barycentric coefficients of the point
+			auto coeffs = tm.get_bary(point);
+			int offsets[DIM] = {4, 6, 4};
+			for (int i = 0; i < DIM; i++)
+			{
+				int elem = tm.which(i, coeffs);
+				if (elem >= 0 && intersection_results(point_ind).dimensionality > (Dimensionality)i)
+				{
+					auto face2elem = mesh_.get_adj(Omega_h::REGION, i).ab2b;
+					auto elem_ind = face2elem[offsets[i]*val.index + elem];
+					intersection_results(point_ind).dimensionality = (Dimensionality)i;
+					intersection_results(point_ind).element_id = elem_ind;
+					for (int j = 0; j < DIM + 1; j++)
+						intersection_results(point_ind).parametric_coords(j) = coeffs[j];
+					return;
+				}
+			}
 
-	tree.query(execution_space, 
-			   pcms_Coordinate_View_Tagged<Omega_h::ExecSpace::memory_space, 2>{coords},
-			   CallOnIntersect);
-	return intersection_results;
+			if (tm.which(DIM, coeffs) >= 0 
+					&& intersection_results(point_ind).dimensionality >= Dimensionality::REGION)
+			{
+				intersection_results(point_ind).dimensionality = Dimensionality::REGION;
+				intersection_results(point_ind).element_id = (LO)val.index;
+				for (int j = 0; j < DIM + 1; j++)
+						intersection_results(point_ind).parametric_coords(j) = coeffs[j];
+			}
+		};
+
+		((TreeWrapper3D::Tree_t*)tree->get_tree())->query(execution_space, 
+				   pcms_Coordinate_View_Tagged<Omega_h::ExecSpace::memory_space, DIM>{coords},
+				   CallOnIntersect);
+		return intersection_results;
+	}
 }
 
-TreePointSearch3D::TreePointSearch3D(const Omega_h::Mesh& mesh) : mesh_(mesh)
+std::unique_ptr<TreeWrapper> TreePointSearch::make_tree(const Omega_h::Mesh& mesh) const
 {
-	if (mesh.dim() != 3) 
-	{
-		throw pcms_error("Could not construct TreePointSearch3D, invalid mesh dimension");
-	}
-
-	Omega_h::ExecSpace execution_space;
+	ExecSpace execution_space;
 	using DeviceType = Kokkos::Device<Omega_h::ExecSpace, 
 									  Omega_h::ExecSpace::memory_space>;
-	Omega_h_Mesh_Tagged<DeviceType, 3, double> tagged_mesh{mesh};
-	tree = ArborX::BVH(execution_space, 
-						ArborX::Experimental::attach_indices(tagged_mesh));
-
-	mappings = Kokkos::View<Mapping3D*, Omega_h::ExecSpace::memory_space>("mappings", mesh.nelems());
-	auto mappings_h = Kokkos::create_mirror_view(mappings);
-	for (int i = 0; i < mesh.nelems(); i++)
+	if (mesh.dim() == 2)
 	{
-		mappings_h[i] = Mapping3D(i, mesh);
-	}
-	Kokkos::deep_copy(execution_space, mappings, mappings_h);
-}
-
-Kokkos::View<PointSearch3D::Result*> TreePointSearch3D::apply(
-	const CoordinateView<Omega_h::ExecSpace::memory_space>& coords) const
-{
-	if (coords.GetCoordinateSystem() != pcms::CoordinateSystem::Cartesian)
-	{
-		throw pcms_error("TreePointSearch3D::apply only implemented for"
-						 " Cartesian coordinates");
-	}
+		Omega_h_Mesh_Tagged<DeviceType, 2, double> tagged_mesh{mesh};
+		TreeWrapper2D::Tree_t tree = ArborX::BVH(execution_space, 
+							ArborX::Experimental::attach_indices(tagged_mesh));
 	
-	Omega_h::ExecSpace execution_space;
-	Kokkos::View<PointSearch3D::Result*> intersection_results("3D intersection results",
-																coords.GetCoordinates().extent(0));
-	auto results_h = Kokkos::create_mirror_view(intersection_results);
-	for (int i = 0; i < intersection_results.size(); i++) 
-		results_h[i] = Result_t{
-			.dimensionality = Dim_t::REGION,
-			.element_id = -1,
-			.parametric_coords = {-1, -1, -1}
-		};
-	Kokkos::deep_copy(execution_space, intersection_results, results_h);
-	Kokkos::Array<int, 3> n_adj = {4, 6, 4};
-
-	auto CallOnIntersect = KOKKOS_LAMBDA <typename Predicate, typename Value>
-	(Predicate const &predicate, Value const & val)
+		TreeWrapper2D::Mappings_t mappings = Kokkos::View<Mapping2D*, Omega_h::ExecSpace::memory_space>("mappings", mesh.nelems());
+		auto mappings_h = Kokkos::create_mirror_view(mappings);
+		for (int i = 0; i < mesh.nelems(); i++)
+		{
+			mappings_h[i] = Mapping2D(i, mesh);
+		}
+		Kokkos::deep_copy(execution_space, mappings, mappings_h);
+		return std::make_unique<TreeWrapper2D>(mappings, tree);
+	}
+	if (mesh.dim() == 3)
 	{
-		ArborX::Point<3, Omega_h::Real> const& ax = ArborX::getGeometry(predicate);
-		Omega_h::Vector<3> point{ax[0], ax[1], ax[2]};
-		int point_ind = ArborX::getData(predicate);
-		
-		Mapping3D const& tm = mappings(val.index);
-		
-		// calculate the barycentric coefficients of the point
-		auto coeffs = tm.get_bary(point);
-
-		for (int i = 0; i < DIM; i++)
+		Omega_h_Mesh_Tagged<DeviceType, 3, double> tagged_mesh{mesh};
+		TreeWrapper3D::Tree_t tree = ArborX::BVH(execution_space, 
+							ArborX::Experimental::attach_indices(tagged_mesh));
+	
+		TreeWrapper3D::Mappings_t mappings = Kokkos::View<Mapping3D*, Omega_h::ExecSpace::memory_space>("mappings", mesh.nelems());
+		auto mappings_h = Kokkos::create_mirror_view(mappings);
+		for (int i = 0; i < mesh.nelems(); i++)
 		{
-			int elem = tm.which(i, coeffs);
-			if (elem >= 0 && intersection_results(point_ind).dimensionality > (Dim_t)i)
-			{
-				auto region2elem = mesh_.get_adj(Omega_h::REGION, i).ab2b;
-				auto elem_ind = region2elem[n_adj[i]*val.index + elem];
-				intersection_results(point_ind) = Result_t{
-					.dimensionality = (Dim_t)i, 
-					.element_id = elem_ind, 
-					.parametric_coords = coeffs
-				};
-				return;
-			}
+			mappings_h[i] = Mapping3D(i, mesh);
 		}
-		if (tm.which(DIM, coeffs) >= 0 
-			&& intersection_results(point_ind).element_id < 0)
-		{
-			intersection_results(point_ind) = Result_t{
-				.dimensionality = Dim_t::REGION,
-				.element_id = (LO)val.index,
-				.parametric_coords = coeffs
-			};
-		}
-	};
-
-	tree.query(execution_space, 
-			   pcms_Coordinate_View_Tagged<Omega_h::ExecSpace::memory_space, 3>{coords},
-			   CallOnIntersect);
-	return intersection_results;
+		Kokkos::deep_copy(execution_space, mappings, mappings_h);
+		return std::make_unique<TreeWrapper3D>(mappings, tree);
+	}
+	throw pcms_error("Invalid mesh dimension " + std::to_string(mesh.dim()) + ", TreePointSearch only implemented for 2D and 3D");
 }
 
 } // namespace pcms
-
-

--- a/src/pcms/localization/point_localization.cpp
+++ b/src/pcms/localization/point_localization.cpp
@@ -405,22 +405,42 @@ TreePointSearch::Results TreePointSearch::apply(
 [[nodiscard]] LO TreePointSearch::GetOwningElementId(
 	const TreePointSearch::Results& results, int i)
 {
-	return pcms::GetOwningElementId(mesh_, mesh_.dim(), (int)results.dimensionalities(i),
-		results.element_ids(i));
+  const Kokkos::View<LO[1]> query_id{""};
+  const Kokkos::View<Dimensionality[1]> dim{""};
+  Kokkos::parallel_for(1, KOKKOS_LAMBDA(const int){
+    query_id(0) = (results.element_ids(i) < 0) ? -results.element_ids(i) : results.element_ids(i);
+    dim(0) = results.dimensionalities(i);
+  });
+  auto query_id_h = Kokkos::create_mirror_view(query_id);  
+  auto dim_h = Kokkos::create_mirror_view(dim);
+  Kokkos::deep_copy(query_id_h, query_id);
+  Kokkos::deep_copy(dim_h, dim);
+	return pcms::GetOwningElementId(mesh_, mesh_.dim(), static_cast<int>(dim_h(0)),
+		query_id_h(0));
 }
 
 [[nodiscard]] Kokkos::View<LO*> TreePointSearch::GetOwningElementIds(
 	const TreePointSearch::Results& results)
 {
-	ExecSpace execution_space;
 	Kokkos::View<LO*> owning_ids("Owning element IDs", 
 		results.dimensionalities.size());
-	auto owning_ids_h = Kokkos::create_mirror_view(owning_ids);
-	for (int i = 0; i < owning_ids_h.size(); i++)
-	{
-		owning_ids_h[i] = GetOwningElementId(results, i);
-	}
-	Kokkos::deep_copy(execution_space, owning_ids, owning_ids_h);
+	auto vert2elem = mesh_.ask_up(Omega_h::VERT, mesh_.dim());
+	auto edge2elem = mesh_.ask_up(Omega_h::EDGE, mesh_.dim());
+	auto face2elem = (mesh_.dim() == 3) ? mesh_.ask_up(Omega_h::FACE, mesh_.dim()) : Omega_h::Adj{};
+	auto mesh_dim = mesh_.dim();
+	Kokkos::parallel_for(owning_ids.size(), KOKKOS_LAMBDA(const int i){
+		if (static_cast<int>(results.dimensionalities(i)) == mesh_dim) {
+			owning_ids(i) = abs(results.element_ids(i));
+		} else if (static_cast<int>(results.dimensionalities(i)) == 2) {
+			owning_ids(i) = GetOwningElementIdFromAdj(face2elem, 2, mesh_dim, results.element_ids(i));
+		} else if (static_cast<int>(results.dimensionalities(i)) == 1) {
+			owning_ids(i) = GetOwningElementIdFromAdj(edge2elem, 1, mesh_dim, results.element_ids(i));
+		} else if (static_cast<int>(results.dimensionalities(i)) == 0) {
+			owning_ids(i) = GetOwningElementIdFromAdj(vert2elem, 0, mesh_dim, results.element_ids(i));
+		} else {
+			owning_ids(i) = -1;
+		}
+	});
 	return owning_ids;
 }
 

--- a/src/pcms/localization/point_localization.cpp
+++ b/src/pcms/localization/point_localization.cpp
@@ -330,7 +330,7 @@ int Mapping3D::which_face(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords
 */
 int Mapping3D::within_elem(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords) const
 {
-	return -1 * (int)(bary_coords[0] >= 0 && bary_coords[1] >= 0 && bary_coords[2] >= 0 && bary_coords[3] >= 0);
+	return -1 * (int)!(bary_coords[0] >= 0 && bary_coords[1] >= 0 && bary_coords[2] >= 0 && bary_coords[3] >= 0);
 }
 
 // constructs the tetrahedron from the mesh's spatial data
@@ -441,6 +441,95 @@ Kokkos::View<PointSearch2D::Result*> TreePointSearch2D::apply(
 
 	tree.query(execution_space, 
 			   pcms_Coordinate_View_Tagged<Omega_h::ExecSpace::memory_space, 2>{coords},
+			   CallOnIntersect);
+	return intersection_results;
+}
+
+TreePointSearch3D::TreePointSearch3D(const Omega_h::Mesh& mesh) : mesh_(mesh)
+{
+	if (mesh.dim() != 3) 
+	{
+		throw pcms_error("Could not construct TreePointSearch3D, invalid mesh dimension");
+	}
+
+	Omega_h::ExecSpace execution_space;
+	using DeviceType = Kokkos::Device<Omega_h::ExecSpace, 
+									  Omega_h::ExecSpace::memory_space>;
+	Omega_h_Mesh_Tagged<DeviceType, 3, double> tagged_mesh{mesh};
+	tree = ArborX::BVH(execution_space, 
+						ArborX::Experimental::attach_indices(tagged_mesh));
+
+	mappings = Kokkos::View<Mapping3D*, Omega_h::ExecSpace::memory_space>("mappings", mesh.nelems());
+	auto mappings_h = Kokkos::create_mirror_view(mappings);
+	for (int i = 0; i < mesh.nelems(); i++)
+	{
+		mappings_h[i] = Mapping3D(i, mesh);
+	}
+	Kokkos::deep_copy(execution_space, mappings, mappings_h);
+}
+
+Kokkos::View<PointSearch3D::Result*> TreePointSearch3D::apply(
+	const CoordinateView<Omega_h::ExecSpace::memory_space>& coords) const
+{
+	if (coords.GetCoordinateSystem() != pcms::CoordinateSystem::Cartesian)
+	{
+		throw pcms_error("TreePointSearch3D::apply only implemented for"
+						 " Cartesian coordinates");
+	}
+	
+	Omega_h::ExecSpace execution_space;
+	Kokkos::View<PointSearch3D::Result*> intersection_results("3D intersection results",
+																coords.GetCoordinates().extent(0));
+	auto results_h = Kokkos::create_mirror_view(intersection_results);
+	for (int i = 0; i < intersection_results.size(); i++) 
+		results_h[i] = Result_t{
+			.dimensionality = Dim_t::REGION,
+			.element_id = -1,
+			.parametric_coords = {-1, -1, -1}
+		};
+	Kokkos::deep_copy(execution_space, intersection_results, results_h);
+	Kokkos::Array<int, 3> n_adj = {4, 6, 4};
+
+	auto CallOnIntersect = KOKKOS_LAMBDA <typename Predicate, typename Value>
+	(Predicate const &predicate, Value const & val)
+	{
+		ArborX::Point<3, Omega_h::Real> const& ax = ArborX::getGeometry(predicate);
+		Omega_h::Vector<3> point{ax[0], ax[1], ax[2]};
+		int point_ind = ArborX::getData(predicate);
+		
+		Mapping3D const& tm = mappings(val.index);
+		
+		// calculate the barycentric coefficients of the point
+		auto coeffs = tm.get_bary(point);
+
+		for (int i = 0; i < DIM; i++)
+		{
+			int elem = tm.which(i, coeffs);
+			if (elem >= 0 && intersection_results(point_ind).dimensionality > (Dim_t)i)
+			{
+				auto region2elem = mesh_.get_adj(Omega_h::REGION, i).ab2b;
+				auto elem_ind = region2elem[n_adj[i]*val.index + elem];
+				intersection_results(point_ind) = Result_t{
+					.dimensionality = (Dim_t)i, 
+					.element_id = elem_ind, 
+					.parametric_coords = coeffs
+				};
+				return;
+			}
+		}
+		if (tm.which(DIM, coeffs) >= 0 
+			&& intersection_results(point_ind).element_id < 0)
+		{
+			intersection_results(point_ind) = Result_t{
+				.dimensionality = Dim_t::REGION,
+				.element_id = (LO)val.index,
+				.parametric_coords = coeffs
+			};
+		}
+	};
+
+	tree.query(execution_space, 
+			   pcms_Coordinate_View_Tagged<Omega_h::ExecSpace::memory_space, 3>{coords},
 			   CallOnIntersect);
 	return intersection_results;
 }

--- a/src/pcms/localization/point_localization.cpp
+++ b/src/pcms/localization/point_localization.cpp
@@ -62,7 +62,7 @@ namespace pcms
 namespace detail
 {
 
-Mapping2D::Mapping2D(int elem_index, Omega_h::Mesh const& mesh)
+Mapping<2>::Mapping(int elem_index, Omega_h::Mesh const& mesh)
 {
 	set_mesh_triangle(elem_index, mesh);
 	bary_transform = { triangle[0] - triangle[2], triangle[1] - triangle[2] };
@@ -71,15 +71,15 @@ Mapping2D::Mapping2D(int elem_index, Omega_h::Mesh const& mesh)
 }
 
 KOKKOS_FUNCTION
-Omega_h::Vector<Mapping2D::DIM + 1> Mapping2D::get_bary(Omega_h::Vector<Mapping2D::DIM> const& p) const
+Omega_h::Vector<Mapping<2>::DIM + 1> Mapping<2>::get_bary(Omega_h::Vector<Mapping<2>::DIM> const& p) const
 {
 	Omega_h::Vector<2> coeffs = bary_transform*(p - triangle[2]);
 	return {coeffs[0], coeffs[1], 1 - coeffs[0] - coeffs[1]};
 }
 
 KOKKOS_FUNCTION
-int Mapping2D::which(int dim, 
-					 Omega_h::Vector<Mapping2D::DIM + 1> const& bary_coords) const
+int Mapping<2>::which(int dim, 
+					 Omega_h::Vector<Mapping<2>::DIM + 1> const& bary_coords) const
 {
 	if (dim == Omega_h::VERT) {
 		return which_vert(bary_coords);
@@ -93,7 +93,7 @@ int Mapping2D::which(int dim,
 	return -1;
 }
 
-int Mapping2D::which_vert(Omega_h::Vector<Mapping2D::DIM + 1> const& bary_coords) const
+int Mapping<2>::which_vert(Omega_h::Vector<Mapping<2>::DIM + 1> const& bary_coords) const
 {
 	for (int i = 0; i < 3; i++)
 	{
@@ -106,7 +106,7 @@ int Mapping2D::which_vert(Omega_h::Vector<Mapping2D::DIM + 1> const& bary_coords
 	return -1;
 }
 
-int Mapping2D::which_edge(Omega_h::Vector<Mapping2D::DIM + 1> const& bary_coords) const
+int Mapping<2>::which_edge(Omega_h::Vector<Mapping<2>::DIM + 1> const& bary_coords) const
 {
 	for (int i = 0; i <= 2; i++)
 	{
@@ -120,12 +120,12 @@ int Mapping2D::which_edge(Omega_h::Vector<Mapping2D::DIM + 1> const& bary_coords
 	return -1;
 }
 
-int Mapping2D::within_elem(Omega_h::Vector<Mapping2D::DIM + 1> const& bary_coords) const
+int Mapping<2>::within_elem(Omega_h::Vector<Mapping<2>::DIM + 1> const& bary_coords) const
 {
 	return -1 * (int)!(bary_coords[0] > 0 && bary_coords[1] > 0 && bary_coords[2] > 0);
 }
 
-void Mapping2D::set_mesh_triangle(int index, Omega_h::Mesh const& mesh)
+void Mapping<2>::set_mesh_triangle(int index, Omega_h::Mesh const& mesh)
 {
 	auto face2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::FACE, Omega_h::VERT).ab2b);
 	auto vert_coords = Omega_h::HostRead(mesh.coords());
@@ -134,12 +134,12 @@ void Mapping2D::set_mesh_triangle(int index, Omega_h::Mesh const& mesh)
 			{vert_coords[face2vert[index*3 + 2]*2], vert_coords[face2vert[index*3 + 2]*2 + 1]}};
 }
 
-double Mapping2D::opposite_edge_len_sq(int i) const
+double Mapping<2>::opposite_edge_len_sq(int i) const
 {
 	return Omega_h::norm_squared(triangle[(i+2)%3] - triangle[(i+1)%3]);
 }
 
-Mapping3D::Mapping3D(int elem_index, Omega_h::Mesh const& mesh)
+Mapping<3>::Mapping(int elem_index, Omega_h::Mesh const& mesh)
 {
 	set_mesh_tet(elem_index, mesh);
 	set_triangle_areas();
@@ -149,15 +149,15 @@ Mapping3D::Mapping3D(int elem_index, Omega_h::Mesh const& mesh)
 }
 
 KOKKOS_FUNCTION
-Omega_h::Vector<Mapping3D::DIM + 1> Mapping3D::get_bary(Omega_h::Vector<Mapping3D::DIM> const& p) const
+Omega_h::Vector<Mapping<3>::DIM + 1> Mapping<3>::get_bary(Omega_h::Vector<Mapping<3>::DIM> const& p) const
 {
 	Omega_h::Vector<3> coeffs = bary_transform*(p - tetrahedron[3]);
 	return {coeffs[0], coeffs[1], coeffs[2], 1 - coeffs[0] - coeffs[1] - coeffs[2]};
 }
 
 KOKKOS_FUNCTION
-int Mapping3D::which(int dim, 
-					 Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords) const
+int Mapping<3>::which(int dim, 
+					 Omega_h::Vector<Mapping<3>::DIM + 1> const& bary_coords) const
 {
 	if (dim == Omega_h::VERT) {
 		return which_vert(bary_coords);
@@ -174,7 +174,7 @@ int Mapping3D::which(int dim,
 	return -1;
 }
 
-int Mapping3D::which_vert(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords) const
+int Mapping<3>::which_vert(Omega_h::Vector<Mapping<3>::DIM + 1> const& bary_coords) const
 {
 	for (int i = 0; i < 4; i++)
 	{
@@ -187,7 +187,7 @@ int Mapping3D::which_vert(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords
 }
 
 
-int Mapping3D::which_edge(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords) const
+int Mapping<3>::which_edge(Omega_h::Vector<Mapping<3>::DIM + 1> const& bary_coords) const
 {
 	int edge_ = 0;
 	for (int i = 0; i < 4; i++)
@@ -213,7 +213,7 @@ int Mapping3D::which_edge(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords
 	return -1;
 }
 
-int Mapping3D::which_face(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords) const
+int Mapping<3>::which_face(Omega_h::Vector<Mapping<3>::DIM + 1> const& bary_coords) const
 {
 	for (int i = 0; i < 4; i++)
 	{
@@ -226,12 +226,12 @@ int Mapping3D::which_face(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords
 	return -1;
 }
 
-int Mapping3D::within_elem(Omega_h::Vector<Mapping3D::DIM + 1> const& bary_coords) const
+int Mapping<3>::within_elem(Omega_h::Vector<Mapping<3>::DIM + 1> const& bary_coords) const
 {
 	return -1 * (int)!(bary_coords[0] >= 0 && bary_coords[1] >= 0 && bary_coords[2] >= 0 && bary_coords[3] >= 0);
 }
 
-void Mapping3D::set_mesh_tet(int index, Omega_h::Mesh const& mesh)
+void Mapping<3>::set_mesh_tet(int index, Omega_h::Mesh const& mesh)
 {
 	auto region2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::REGION, Omega_h::VERT).ab2b);
 	auto vert_coords = Omega_h::HostRead(mesh.coords());
@@ -244,7 +244,7 @@ void Mapping3D::set_mesh_tet(int index, Omega_h::Mesh const& mesh)
 // calculates the areas of each of the faces of the triangle
 // the faces are "named" according to the vertex opposite
 // (i.e., face 0 is defined by points 1, 2, 3)
-void Mapping3D::set_triangle_areas()
+void Mapping<3>::set_triangle_areas()
 {
 	for (int i = 0; i < 4; i++)
 	{
@@ -261,7 +261,7 @@ KOKKOS_FUNCTION void CallOnIntersect2D::operator()(Predicate const &predicate, V
 	Omega_h::Vector<DIM> point{ax[0], ax[1]};
 	int point_ind = ArborX::getData(predicate);
 	
-	detail::Mapping2D const& tm = mappings(val.index);
+	detail::Mapping<2> const& tm = mappings(val.index);
 	
 	// calculate the barycentric coefficients of the point
 	auto coeffs = tm.get_bary(point);
@@ -296,7 +296,7 @@ void CallOnIntersect3D::operator()(Predicate const &predicate, Value const & val
 	Omega_h::Vector<DIM> point{ax[0], ax[1], ax[2]};
 	int point_ind = ArborX::getData(predicate);
 	
-	detail::Mapping3D const& tm = mappings(val.index);
+	detail::Mapping<3> const& tm = mappings(val.index);
 	
 	// calculate the barycentric coefficients of the point
 	auto coeffs = tm.get_bary(point);
@@ -359,11 +359,11 @@ Kokkos::View<TreePointSearch::Result*> TreePointSearch::apply(
 		}
 		Kokkos::deep_copy(execution_space, intersection_results, results_h);
 
-		((detail::TreeWrapper2D::Tree_t*)tree->get_tree())->query(execution_space, 
+		tree->get_tree<2>()->query(execution_space, 
 					detail::Coordinate_View_Adapt<MemorySpace, DIM>{
 					coords.GetCoordinates()},
 					detail::CallOnIntersect2D(
-						*(detail::TreeWrapper2D::Mappings_t*)tree->get_mappings(),
+						*tree->get_mappings<2>(),
 						mesh_.get_adj(Omega_h::FACE, 0).ab2b,
 						mesh_.get_adj(Omega_h::FACE, 1).ab2b,
 						intersection_results
@@ -385,20 +385,13 @@ Kokkos::View<TreePointSearch::Result*> TreePointSearch::apply(
 			results_h[i].parametric_coords = {-1, -1, -1, -1};
 		}
 		Kokkos::deep_copy(execution_space, intersection_results, results_h);
-		
-		detail::TreeWrapper3D::Mappings_t mappings = *(detail::TreeWrapper3D::Mappings_t*)tree->get_mappings();
-		Omega_h::LOs adjacencies[3] = {
-			mesh_.get_adj(Omega_h::REGION, 0).ab2b,
-			mesh_.get_adj(Omega_h::REGION, 1).ab2b,
-			mesh_.get_adj(Omega_h::REGION, 2).ab2b
-		};
 
-		((detail::TreeWrapper3D::Tree_t*)tree->get_tree())->query(execution_space, 
+		tree->get_tree<3>()->query(execution_space, 
 			detail::Coordinate_View_Adapt<MemorySpace, 
 			DIM>{
 			coords.GetCoordinates()},
 			detail::CallOnIntersect3D(
-				*(detail::TreeWrapper3D::Mappings_t*)tree->get_mappings(),
+				*tree->get_mappings<3>(),
 				mesh_.get_adj(Omega_h::REGION, 0).ab2b,
 				mesh_.get_adj(Omega_h::REGION, 1).ab2b,
 				mesh_.get_adj(Omega_h::REGION, 2).ab2b,
@@ -422,21 +415,21 @@ std::unique_ptr<detail::TreeWrapper> TreePointSearch::make_tree(const Omega_h::M
 			mesh.coords()
 		};
 		
-		detail::TreeWrapper2D::Tree_t tree = detail::TreeWrapper2D::Tree_t(
+		detail::TreeWrapper::Tree_t<2> tree = detail::TreeWrapper::Tree_t<2>(
 			execution_space,
 			ArborX::Experimental::attach_indices(tagged_mesh));
 			
-		detail::TreeWrapper2D::Mappings_t mappings = detail::TreeWrapper2D::Mappings_t(
+		detail::TreeWrapper::Mappings_t<2> mappings = detail::TreeWrapper::Mappings_t<2>(
 			"mappings", 
 			mesh.nelems());
 		
 		auto mappings_h = Kokkos::create_mirror_view(mappings);
 		for (int i = 0; i < mesh.nelems(); i++)
 		{
-			mappings_h[i] = detail::Mapping2D(i, mesh);
+			mappings_h[i] = detail::Mapping<2>(i, mesh);
 		}
 		Kokkos::deep_copy(execution_space, mappings, mappings_h);
-		return std::make_unique<detail::TreeWrapper2D>(mappings, tree);
+		return std::make_unique<detail::TreeWrapper>(mappings, tree);
 	}
 	if (mesh.dim() == 3)
 	{
@@ -445,21 +438,21 @@ std::unique_ptr<detail::TreeWrapper> TreePointSearch::make_tree(const Omega_h::M
 			mesh.get_adj(Omega_h::REGION, Omega_h::VERT).ab2b,
 			mesh.coords()
 		};
-		detail::TreeWrapper3D::Tree_t tree = detail::TreeWrapper3D::Tree_t(
+		detail::TreeWrapper::Tree_t<3> tree = detail::TreeWrapper::Tree_t<3>(
 			execution_space, 
 			ArborX::Experimental::attach_indices(tagged_mesh));
 	
-		detail::TreeWrapper3D::Mappings_t mappings = detail::TreeWrapper3D::Mappings_t(
+		detail::TreeWrapper::Mappings_t<3> mappings = detail::TreeWrapper::Mappings_t<3>(
 			"mappings", 
 			mesh.nelems());
 		
 		auto mappings_h = Kokkos::create_mirror_view(mappings);
 		for (int i = 0; i < mesh.nelems(); i++)
 		{
-			mappings_h[i] = detail::Mapping3D(i, mesh);
+			mappings_h[i] = detail::Mapping<3>(i, mesh);
 		}
 		Kokkos::deep_copy(execution_space, mappings, mappings_h);
-		return std::make_unique<detail::TreeWrapper3D>(mappings, tree);
+		return std::make_unique<detail::TreeWrapper>(mappings, tree);
 	}
 	throw pcms_error("Invalid mesh dimension " + std::to_string(mesh.dim()) + ", TreePointSearch only implemented for 2D and 3D");
 }

--- a/src/pcms/localization/point_localization.cpp
+++ b/src/pcms/localization/point_localization.cpp
@@ -62,9 +62,8 @@ namespace pcms
 namespace detail
 {
 
-Mapping<2>::Mapping(int elem_index, Omega_h::Mesh const& mesh)
+Mapping<2>::Mapping(Omega_h::Matrix<Mapping<2>::DIM,Mapping<2>::DIM+1> const& triangle_) : triangle(triangle_)
 {
-	set_mesh_triangle(elem_index, mesh);
 	bary_transform = { triangle[0] - triangle[2], triangle[1] - triangle[2] };
 	triangle_area = 0.5*fabs(Omega_h::determinant(bary_transform));
 	bary_transform = Omega_h::invert(bary_transform);
@@ -125,23 +124,14 @@ int Mapping<2>::within_elem(Omega_h::Vector<Mapping<2>::DIM + 1> const& bary_coo
 	return -1 * (int)!(bary_coords[0] > 0 && bary_coords[1] > 0 && bary_coords[2] > 0);
 }
 
-void Mapping<2>::set_mesh_triangle(int index, Omega_h::Mesh const& mesh)
-{
-	auto face2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::FACE, Omega_h::VERT).ab2b);
-	auto vert_coords = Omega_h::HostRead(mesh.coords());
-	triangle = Omega_h::Matrix<2,3>{{vert_coords[face2vert[index*3]*2], vert_coords[face2vert[index*3]*2 + 1]},
-			{vert_coords[face2vert[index*3 + 1]*2], vert_coords[face2vert[index*3 + 1]*2 + 1]},
-			{vert_coords[face2vert[index*3 + 2]*2], vert_coords[face2vert[index*3 + 2]*2 + 1]}};
-}
-
 double Mapping<2>::opposite_edge_len_sq(int i) const
 {
 	return Omega_h::norm_squared(triangle[(i+2)%3] - triangle[(i+1)%3]);
 }
 
-Mapping<3>::Mapping(int elem_index, Omega_h::Mesh const& mesh)
+Mapping<3>::Mapping(Omega_h::Matrix<Mapping<3>::DIM,Mapping<3>::DIM+1> const& tetrahedron_)
+	: tetrahedron(tetrahedron_)
 {
-	set_mesh_tet(elem_index, mesh);
 	set_triangle_areas();
 	bary_transform = { tetrahedron[0] - tetrahedron[3], tetrahedron[1] - tetrahedron[3], tetrahedron[2] - tetrahedron[3] };
 	tetrahedron_volume = fabs(Omega_h::determinant(bary_transform))/6.;
@@ -229,16 +219,6 @@ int Mapping<3>::which_face(Omega_h::Vector<Mapping<3>::DIM + 1> const& bary_coor
 int Mapping<3>::within_elem(Omega_h::Vector<Mapping<3>::DIM + 1> const& bary_coords) const
 {
 	return -1 * (int)!(bary_coords[0] >= 0 && bary_coords[1] >= 0 && bary_coords[2] >= 0 && bary_coords[3] >= 0);
-}
-
-void Mapping<3>::set_mesh_tet(int index, Omega_h::Mesh const& mesh)
-{
-	auto region2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::REGION, Omega_h::VERT).ab2b);
-	auto vert_coords = Omega_h::HostRead(mesh.coords());
-	tetrahedron = {{vert_coords[region2vert[index*4]*3], vert_coords[region2vert[index*4]*3 + 1], vert_coords[region2vert[index*4]*3 + 2]},
-	{vert_coords[region2vert[index*4 + 1]*3], vert_coords[region2vert[index*4 + 1]*3 + 1], vert_coords[region2vert[index*4 + 1]*3 + 2]},
-	{vert_coords[region2vert[index*4 + 2]*3], vert_coords[region2vert[index*4 + 2]*3 + 1], vert_coords[region2vert[index*4 + 2]*3 + 2]},
-	{vert_coords[region2vert[index*4 + 3]*3], vert_coords[region2vert[index*4 + 3]*3 + 1], vert_coords[region2vert[index*4 + 3]*3 + 2]}};
 }
 
 // calculates the areas of each of the faces of the triangle
@@ -423,10 +403,17 @@ std::unique_ptr<detail::TreeWrapper> TreePointSearch::make_tree(const Omega_h::M
 			"mappings", 
 			mesh.nelems());
 		
+		auto face2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::FACE, Omega_h::VERT).ab2b);
+		auto vert_coords = Omega_h::HostRead(mesh.coords());
+		
 		auto mappings_h = Kokkos::create_mirror_view(mappings);
 		for (int i = 0; i < mesh.nelems(); i++)
 		{
-			mappings_h[i] = detail::Mapping<2>(i, mesh);
+			Omega_h::Matrix<2,3> triangle = {
+				{vert_coords[face2vert[i*3]*2], vert_coords[face2vert[i*3]*2 + 1]},
+				{vert_coords[face2vert[i*3 + 1]*2], vert_coords[face2vert[i*3 + 1]*2 + 1]},
+				{vert_coords[face2vert[i*3 + 2]*2], vert_coords[face2vert[i*3 + 2]*2 + 1]}};
+			mappings_h[i] = detail::Mapping<2>(triangle);
 		}
 		Kokkos::deep_copy(execution_space, mappings, mappings_h);
 		return std::make_unique<detail::TreeWrapper>(mappings, tree);
@@ -446,10 +433,18 @@ std::unique_ptr<detail::TreeWrapper> TreePointSearch::make_tree(const Omega_h::M
 			"mappings", 
 			mesh.nelems());
 		
+		auto region2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::REGION, Omega_h::VERT).ab2b);
+		auto vert_coords = Omega_h::HostRead(mesh.coords());
+
 		auto mappings_h = Kokkos::create_mirror_view(mappings);
 		for (int i = 0; i < mesh.nelems(); i++)
 		{
-			mappings_h[i] = detail::Mapping<3>(i, mesh);
+			Omega_h::Matrix<3,4> tetrahedron = {
+				{vert_coords[region2vert[i*4]*3], vert_coords[region2vert[i*4]*3 + 1], vert_coords[region2vert[i*4]*3 + 2]},
+				{vert_coords[region2vert[i*4 + 1]*3], vert_coords[region2vert[i*4 + 1]*3 + 1], vert_coords[region2vert[i*4 + 1]*3 + 2]},
+				{vert_coords[region2vert[i*4 + 2]*3], vert_coords[region2vert[i*4 + 2]*3 + 1], vert_coords[region2vert[i*4 + 2]*3 + 2]},
+				{vert_coords[region2vert[i*4 + 3]*3], vert_coords[region2vert[i*4 + 3]*3 + 1], vert_coords[region2vert[i*4 + 3]*3 + 2]}};
+			mappings_h[i] = detail::Mapping<3>(tetrahedron);
 		}
 		Kokkos::deep_copy(execution_space, mappings, mappings_h);
 		return std::make_unique<detail::TreeWrapper>(mappings, tree);

--- a/src/pcms/localization/point_localization.h
+++ b/src/pcms/localization/point_localization.h
@@ -177,7 +177,7 @@ private:
 	double opposite_edge_len_sq(int i) const;
 	
 	// REPRESENTATION
-	Kokkos::View<Real*> tolerances_;
+	Omega_h::Vector<DIM> tolerances_;
 	// representation of the barycentric coordinate mapping, source:
 	// https://en.wikipedia.org/wiki/Barycentric_coordinate_system#Edge_approach
 	Omega_h::Matrix<DIM,DIM> bary_transform; // Column-major order
@@ -302,7 +302,7 @@ private:
 	KOKKOS_INLINE_FUNCTION int edge(int i) const 
 	{ return (i < 4 && i > 0) ? (OFFSETS & 3 << ((i-1)*2))>>((i-1)*2) : i; }
 	// representation
-	Kokkos::View<Real*> tolerances_;
+	Omega_h::Vector<DIM> tolerances_;
 	Omega_h::Matrix<DIM,DIM> bary_transform; // Column-major order
 	Omega_h::Matrix<DIM,DIM+1> tetrahedron;
 	Omega_h::Vector<DIM+1> face_areas;
@@ -375,10 +375,10 @@ public:
 	
 	TreePointSearch(Omega_h::Mesh& mesh) : 
 		PointSearch(PointSearchTolerances("tree point search tolerances", mesh.dim())), 
-		mesh_(mesh), 
-		tree(make_tree(mesh))
+		mesh_(mesh)
 	{
 		Kokkos::deep_copy(tolerances_, 1e-12);
+		tree = make_tree(mesh);
 	}
 	TreePointSearch(Omega_h::Mesh& mesh, const PointSearchTolerances& tolerances) : PointSearch(tolerances), mesh_(mesh), tree(make_tree(mesh)) {}
 	~TreePointSearch() = default;

--- a/src/pcms/localization/point_localization.h
+++ b/src/pcms/localization/point_localization.h
@@ -485,40 +485,7 @@ public:
 	* Intersection callback, 
 	*/
 	template <typename Predicate, typename Value>
-	KOKKOS_FUNCTION void operator()(Predicate const &predicate, Value const & val) const
-	{
-		ArborX::Point<DIM, Omega_h::Real> const& ax = ArborX::getGeometry(predicate);
-		Omega_h::Vector<DIM> point{ax[0], ax[1], ax[2]};
-		int point_ind = ArborX::getData(predicate);
-		
-		detail::Mapping3D const& tm = mappings(val.index);
-		
-		// calculate the barycentric coefficients of the point
-		auto coeffs = tm.get_bary(point);
-		int offsets[DIM] = {4, 6, 4};
-		for (int i = 0; i < DIM; i++)
-		{
-			int elem = tm.which(i, coeffs);
-			if (elem >= 0 && intersection_results(point_ind).dimensionality > (TreePointSearch::Dimensionality)i)
-			{
-				auto elem_ind = adjacencies[i][offsets[i]*val.index + elem];
-				intersection_results(point_ind).dimensionality = (TreePointSearch::Dimensionality)i;
-				intersection_results(point_ind).element_id = elem_ind;
-				for (int j = 0; j < DIM + 1; j++)
-					intersection_results(point_ind).parametric_coords(j) = coeffs[j];
-				return;
-			}
-		}
-
-		if (tm.which(DIM, coeffs) >= 0 
-				&& intersection_results(point_ind).dimensionality >= TreePointSearch::Dimensionality::REGION)
-		{
-			intersection_results(point_ind).dimensionality = TreePointSearch::Dimensionality::REGION;
-			intersection_results(point_ind).element_id = (LO)val.index;
-			for (int j = 0; j < DIM + 1; j++)
-					intersection_results(point_ind).parametric_coords(j) = coeffs[j];
-		}
-	}
+	KOKKOS_FUNCTION void operator()(Predicate const &predicate, Value const & val) const;
 private:
 	Kokkos::View<Mapping3D*, MemorySpace> mappings;
 	Omega_h::LOs adjacencies[3];
@@ -545,39 +512,7 @@ public:
 	};
 	
 	template <typename Predicate, typename Value>
-	KOKKOS_FUNCTION void operator()(Predicate const &predicate, Value const & val) const
-	{
-		ArborX::Point<DIM, Omega_h::Real> const& ax = ArborX::getGeometry(predicate);
-		Omega_h::Vector<DIM> point{ax[0], ax[1]};
-		int point_ind = ArborX::getData(predicate);
-		
-		detail::Mapping2D const& tm = mappings(val.index);
-		
-		// calculate the barycentric coefficients of the point
-		auto coeffs = tm.get_bary(point);
-
-		for (int i = 0; i < DIM; i++)
-		{
-			int elem = tm.which(i, coeffs);
-			if (elem >= 0 && intersection_results(point_ind).dimensionality > (TreePointSearch::Dimensionality)i)
-			{
-				auto elem_ind = adjacencies[i][3*val.index + elem];
-				intersection_results(point_ind).dimensionality = (TreePointSearch::Dimensionality)i;
-				intersection_results(point_ind).element_id = elem_ind;
-				for (int j = 0; j < DIM + 1; j++)
-					intersection_results(point_ind).parametric_coords(j) = coeffs[j];
-				return;
-			}
-		}
-		if (tm.which(DIM, coeffs) >= 0 
-			&& intersection_results(point_ind).dimensionality > TreePointSearch::Dimensionality::FACE)
-		{
-			intersection_results(point_ind).dimensionality = TreePointSearch::Dimensionality::FACE;
-			intersection_results(point_ind).element_id = (LO)val.index;
-			for (int j = 0; j < DIM + 1; j++)
-					intersection_results(point_ind).parametric_coords(j) = coeffs[j];
-		}
-	}
+	KOKKOS_FUNCTION void operator()(Predicate const &predicate, Value const & val) const;
 private:
 	Kokkos::View<Mapping2D*, MemorySpace> mappings;
 	Omega_h::LOs adjacencies[2];

--- a/src/pcms/localization/point_localization.h
+++ b/src/pcms/localization/point_localization.h
@@ -102,10 +102,22 @@ public:
 	KOKKOS_FUNCTION
 	Omega_h::Vector<DIM + 1> get_bary(Omega_h::Vector<DIM> const& p) const;
 	/**
-	* @brief Determines which entity of a particular dimension a point intersects
+	* @brief Determines which entity of a dimension `ent_dim` a point intersects
 	*		 from the barycentric coordinates
 	* 
-	* This function determines the offset in the Omega_h::Adj structure
+	* If the point corresponding to the input barycentric coordinates intersects 
+	* any entities with dimension `ent_dim` bordering the element this mapping is 
+	* constructed from, this function determines the offset in the 
+	* Omega_h::Adj::ab2b structure coresponding to FACE -> `ent_dim` adjacency.
+	* If the point does not intersect a border entity, this function returns -1
+	* 
+	* @param ent_dim the dimension of the entities we want to check intersection
+	* 				 with
+	* @param bary_coords the barycentric coordinates computed by this mapping of
+	*					 a point in global space
+	* @returns -1 if the point does not intersect any entities, or the offset of
+	*		   the intersected entity in the Omega_h::Adj::ab2b structure 
+	*		   coresponding to FACE -> `ent_dim` adjacency
 	*/
 	KOKKOS_FUNCTION
 	int which(
@@ -195,6 +207,24 @@ public:
 	KOKKOS_FUNCTION
 	Omega_h::Vector<DIM + 1> get_bary(Omega_h::Vector<DIM> const& p) const;
 
+	/**
+	* @brief Determines which entity of dimension `ent_dim` a point intersects
+	*		 from the barycentric coordinates
+	* 
+	* If the point corresponding to the input barycentric coordinates intersects 
+	* any entities with dimension `ent_dim` bordering the element this mapping is 
+	* constructed from, this function determines the offset in the 
+	* Omega_h::Adj::ab2b structure coresponding to REGION -> `ent_dim` adjacency.
+	* If the point does not intersect a border entity, this function returns -1
+	* 
+	* @param ent_dim the dimension of the entities we want to check intersection
+	* 				 with
+	* @param bary_coords the barycentric coordinates computed by this mapping of
+	*					 a point in global space
+	* @returns -1 if the point does not intersect any entities, or the offset of
+	*		   the intersected entity in the Omega_h::Adj::ab2b structure 
+	*		   coresponding to REGION -> `ent_dim` adjacency
+	*/
 	KOKKOS_FUNCTION
 	int which(int ent_dim, 
 					  Omega_h::Vector<DIM+1> const& bary_coords) const;
@@ -244,8 +274,20 @@ private:
 	*/
 	KOKKOS_FUNCTION
 	int within_elem(Omega_h::Vector<DIM+1> const& bary_coords) const;
-	
+	/**
+	* @brief Constructs the tetrahedron the mapping corresponds to
+	* @param index the element ID of the tetrahedron
+	* @param mesh the Omega_h::Mesh with the spatial information for the 
+	* 			  tetrahedron corresponding to `index`
+	*/
 	void set_mesh_tet(int index, Omega_h::Mesh const& mesh);
+	/**
+	* @brief Calculates the areas of each face in the tetrahedron the mapping 
+	* 		 corresponds to
+	* @param index the element ID of the tetrahedron
+	* @param mesh the Omega_h::Mesh with the spatial information for the 
+	* 			  tetrahedron corresponding to `index`
+	*/
 	void set_triangle_areas();
 	// returns the actual face/edge offset from the barycentric offset
 	KOKKOS_INLINE_FUNCTION int face(int i) const 
@@ -262,36 +304,86 @@ private:
 	static const char OFFSETS = 1 << 4 | 3 << 2 | 2;
 };
 
+/**
+* Wrapper base class for the ArborX::BVH and Mappings classes, this is a *rough*
+* workaround for ArborX::BVH being templated on dimension
+*/
 struct TreeWrapper
 {
+	/**
+	* @brief returns a pointer to an ArborX tree
+	*/
 	virtual void* get_tree() = 0;
+	/**
+	* @brief returns a pointer to a Kokkos::View of Mappings
+	*/
 	virtual void* get_mappings() = 0;
 };
 
+/**
+* Wraper class for 2D ArborX::BVH and Mapping2D
+*/
 struct TreeWrapper2D : TreeWrapper
 {
+	/**
+	* typedefs for clarity in later code
+	*/
 	using Mappings_t = Kokkos::View<Mapping2D*, Omega_h::ExecSpace::memory_space>;
 	using Tree_t = ArborX::BVH<Omega_h::ExecSpace::memory_space,
 			ArborX::PairValueIndex<ArborX::Box<2, double>, unsigned>>;
 	
+	/**
+	* @brief Constructor, sets the View of Mappings and the tree
+	* @param mappings the mappings for every triangle in an Omega_h::Mesh
+	* @param tree an ArborX::BVH constructed fom an Omega_h::Mesh
+	*/
 	TreeWrapper2D(const Mappings_t& mappings, const Tree_t& tree) : mappings_(mappings), tree_(tree) {}
+	/**
+	* @brief default destructor
+	*/
 	~TreeWrapper2D() = default;
+	/**
+	* @brief Returns a pointer to the ArborX::BVH
+	*/
 	void* get_tree() override { return &tree_; };
+	/**
+	* @brief Returns a pointer to the Kokkos::View of Mapping2Ds
+	*/
 	void* get_mappings() override {return &mappings_; };
 private:
 	Tree_t tree_;
 	Mappings_t mappings_;
 };
 
+/**
+* Wraper class for 3D ArborX::BVH and Mapping3D
+*/
 struct TreeWrapper3D : TreeWrapper
 {
+	/**
+	* typedefs for clarity in later code
+	*/
 	using Mappings_t = Kokkos::View<Mapping3D*, Omega_h::ExecSpace::memory_space>;
 	using Tree_t = ArborX::BVH<Omega_h::ExecSpace::memory_space,
 			ArborX::PairValueIndex<ArborX::Box<3, double>, unsigned>>;
 
+	/**
+	* @brief Constructor, sets the View of Mappings and the tree
+	* @param mappings the mappings for every triangle in an Omega_h::Mesh
+	* @param tree an ArborX::BVH constructed fom an Omega_h::Mesh
+	*/
 	TreeWrapper3D(const Mappings_t& mappings, const Tree_t& tree) : mappings_(mappings), tree_(tree) {}
+	/**
+	* @brief default destructor
+	*/
 	~TreeWrapper3D() = default;
+	/**
+	* @brief Returns a pointer to the ArborX::BVH
+	*/
 	void* get_tree() override { return &tree_; };
+	/**
+	* @brief Returns a pointer to the Kokkos::View of Mapping3Ds
+	*/
 	void* get_mappings() override {return &mappings_; };
 private:
 	Tree_t tree_;
@@ -299,6 +391,7 @@ private:
 };
 
 } //namespace detail
+
 /**
  * Point search base class
  */
@@ -307,6 +400,13 @@ class PointSearch
 public:
 	using ExecSpace = Omega_h::ExecSpace;
 	using MemorySpace = ExecSpace::memory_space;
+	/**
+	* Result type gives dimensionality of point intersection, the intersected
+	* element ID, and the barycentric coordinate mapping of that point.
+	* @warning `parametric_coords` is hardcoded at length 4 because Kokkos::Views
+	*		   can only contain fixed width elements as explained in Kokkos
+	*		   Programming Guide sections 5.2.2 and 5.2.3
+	*/
 	struct Result
 	{
 		enum class Dimensionality
@@ -325,8 +425,10 @@ public:
 
 	PointSearch() = default;
 	~PointSearch() = default;
+
 	virtual Kokkos::View<Result*> apply(const CoordinateView<MemorySpace>& coords) const = 0;
 };
+
 
 class TreePointSearch : public PointSearch
 {
@@ -337,6 +439,13 @@ public:
 	using MemorySpace = PointSearch::MemorySpace;
 	TreePointSearch(const Omega_h::Mesh& mesh) : mesh_(mesh), tree(make_tree(mesh)) {}
 	~TreePointSearch() = default;
+	/**
+	* Given a set of points in global coordinates give the ids of the entities
+	* that the points lie within and the parametric coordinates of each point 
+	* within a triangles or tetrahedra adjacent to the intersected entity. 
+	* If the point does not lie within any triangle element. Then the id will 
+	* be a negative number
+	*/
 	Kokkos::View<Result*> apply(
 		const CoordinateView<MemorySpace>& coords) const override;
 private:
@@ -349,6 +458,9 @@ private:
 namespace detail
 {
 
+/**
+* Functor to be called when a point intersects a triangle or tetrahedron
+*/
 class CallOnIntersect3D
 {
 public:
@@ -369,6 +481,9 @@ public:
 		adjacencies[2] = adjacencies2;
 	};
 	
+	/**
+	* Intersection callback, 
+	*/
 	template <typename Predicate, typename Value>
 	KOKKOS_FUNCTION void operator()(Predicate const &predicate, Value const & val) const
 	{
@@ -409,6 +524,7 @@ private:
 	Omega_h::LOs adjacencies[3];
 	Kokkos::View<TreePointSearch::Result*, MemorySpace> intersection_results;
 };
+
 
 class CallOnIntersect2D
 {
@@ -467,6 +583,7 @@ private:
 	Omega_h::LOs adjacencies[2];
 	Kokkos::View<TreePointSearch::Result*, MemorySpace> intersection_results;
 };
+
 } // namespace detail
 
 } // namespace pcms

--- a/src/pcms/localization/point_localization.h
+++ b/src/pcms/localization/point_localization.h
@@ -90,6 +90,8 @@ public:
 	* @param mesh the Omega_h::Mesh with the spatial information of the triangle
 	*/
 	Mapping(int elem_index, Omega_h::Mesh const& mesh);
+
+	Mapping(Omega_h::Matrix<DIM,DIM+1> const& triangle_);
 	/**
 	* @brief Default destructor
 	*/
@@ -194,12 +196,8 @@ public:
 	*/
 	KOKKOS_FUNCTION
 	Mapping() = default;
-	/**
-	* @brief Constructs a barycentric mapping of a triangle in an Omega_h::Mesh
-	* @param elem_index the index of the desired triangle or tetrahedron in the Omega_h::Mesh
-	* @param mesh the Omega_h::Mesh with the spatial information of the triangle
-	*/
-	Mapping(int elem_index, Omega_h::Mesh const& mesh);
+
+	Mapping(Omega_h::Matrix<DIM,DIM+1> const& tetrahedron_);
 	/**
 	* @brief Default destructor
 	*/

--- a/src/pcms/localization/point_localization.h
+++ b/src/pcms/localization/point_localization.h
@@ -371,13 +371,14 @@ public:
 	using ExecSpace = Omega_h::ExecSpace;
 	using MemorySpace = ExecSpace::memory_space;
 	/**
-	* Result type gives dimensionality of point intersection, the intersected
-	* element ID, and the barycentric coordinate mapping of that point.
-	* @warning `parametric_coords` is hardcoded at length 4 because Kokkos::Views
-	*		   can only contain fixed width elements as explained in Kokkos
-	*		   Programming Guide sections 5.2.2 and 5.2.3
+	* Results type gives dimensionalities of point intersection, the intersected
+	* element IDs, and the barycentric coordinate mappings of each point as follows:
+	* the `i`th input point has intersection dimensionality of 
+	* `dimensionalities(i)`, intersected element ID of `element_ids(i)`, and 
+	* likewise parametric coordinate mapping of `parametric_coords(i,0..d)`
+	* where `d` is the dimension of the space
 	*/
-	struct Result
+	struct Results
 	{
 		enum class Dimensionality
 		{
@@ -388,23 +389,23 @@ public:
 			NO_INTERSECT = 4
 		};
 
-		Dimensionality dimensionality;
-		LO element_id;
-		Omega_h::Vector<4> parametric_coords;
+		Kokkos::View<Dimensionality*, MemorySpace> dimensionalities;
+		Kokkos::View<LO*, MemorySpace> element_ids;
+		Kokkos::View<Real**, MemorySpace> parametric_coords;
 	};
 
 	PointSearch() = default;
 	~PointSearch() = default;
 
-	virtual Kokkos::View<Result*> apply(const CoordinateView<MemorySpace>& coords) const = 0;
+	virtual Results apply(const CoordinateView<MemorySpace>& coords) const = 0;
 };
 
 
 class TreePointSearch : public PointSearch
 {
 public:
-	using Result = PointSearch::Result;
-	using Dimensionality = Result::Dimensionality;
+	using Results = PointSearch::Results;
+	using Dimensionality = Results::Dimensionality;
 	using ExecSpace = PointSearch::ExecSpace;
 	using MemorySpace = PointSearch::MemorySpace;
 	
@@ -414,11 +415,10 @@ public:
 	* Given a set of points in global coordinates give the ids of the entities
 	* that the points lie within and the parametric coordinates of each point 
 	* within a triangles or tetrahedra adjacent to the intersected entity. 
-	* If the point does not lie within any triangle element. Then the id will 
-	* be a negative number
+	* If the point does not lie within any triangle element, the id will 
+	* be a negative number.
 	*/
-	Kokkos::View<Result*> apply(
-		const CoordinateView<MemorySpace>& coords) const override;
+	Results apply(const CoordinateView<MemorySpace>& coords) const override;
 private:
 	std::unique_ptr<detail::TreeWrapper> make_tree(const Omega_h::Mesh& mesh) const;
 	// Reference to the input mesh
@@ -443,13 +443,15 @@ public:
 		const Omega_h::LOs& adjacencies0,
 		const Omega_h::LOs& adjacencies1,
 		const Omega_h::LOs& adjacencies2,
-		const Kokkos::View<TreePointSearch::Result*, MemorySpace>& intersection_results_
-	) : mappings(mappings_),  
-		intersection_results(intersection_results_)
+		Kokkos::View<TreePointSearch::Dimensionality*, MemorySpace>& dimensionalities_,
+		Kokkos::View<LO*, MemorySpace>& element_ids_,
+		Kokkos::View<Real**, MemorySpace>& parametric_coords_
+	) : mappings(MakeRank1View(mappings_)),  
+		adjacencies{adjacencies0, adjacencies1, adjacencies2},
+		dimensionalities(MakeRank1View(dimensionalities_)),
+		element_ids(MakeRank1View(element_ids_)),
+		parametric_coords(MakeRank2View(parametric_coords_))
 	{
-		adjacencies[0] = adjacencies0;
-		adjacencies[1] = adjacencies1;
-		adjacencies[2] = adjacencies2;
 	};
 	
 	/**
@@ -458,9 +460,11 @@ public:
 	template <typename Predicate, typename Value>
 	KOKKOS_FUNCTION void operator()(Predicate const &predicate, Value const & val) const;
 private:
-	Kokkos::View<Mapping<3>*, MemorySpace> mappings;
+	Rank1View<const Mapping<3>, MemorySpace> mappings;
 	Omega_h::LOs adjacencies[3];
-	Kokkos::View<TreePointSearch::Result*, MemorySpace> intersection_results;
+	Rank1View<TreePointSearch::Dimensionality, MemorySpace> dimensionalities;
+	Rank1View<LO, MemorySpace> element_ids;
+	Rank2View<Real, MemorySpace> parametric_coords;
 };
 
 
@@ -474,20 +478,25 @@ public:
 		const Kokkos::View<Mapping<2>*, MemorySpace>& mappings_,
 		const Omega_h::LOs& adjacencies0,
 		const Omega_h::LOs& adjacencies1,
-		const Kokkos::View<TreePointSearch::Result*, MemorySpace>& intersection_results_
-	) : mappings(mappings_),  
-		intersection_results(intersection_results_)
+		Kokkos::View<TreePointSearch::Dimensionality*, MemorySpace>& dimensionalities_,
+		Kokkos::View<LO*, MemorySpace>& element_ids_,
+		Kokkos::View<Real**, MemorySpace>& parametric_coords_
+	) : mappings(MakeRank1View(mappings_)),  
+		adjacencies{adjacencies0, adjacencies1},
+		dimensionalities(MakeRank1View(dimensionalities_)),
+		element_ids(MakeRank1View(element_ids_)),
+		parametric_coords(MakeRank2View(parametric_coords_))
 	{
-		adjacencies[0] = adjacencies0;
-		adjacencies[1] = adjacencies1;
 	};
 	
 	template <typename Predicate, typename Value>
 	KOKKOS_FUNCTION void operator()(Predicate const &predicate, Value const & val) const;
 private:
-	Kokkos::View<Mapping<2>*, MemorySpace> mappings;
+	Rank1View<const Mapping<2>, MemorySpace> mappings;
 	Omega_h::LOs adjacencies[2];
-	Kokkos::View<TreePointSearch::Result*, MemorySpace> intersection_results;
+	Rank1View<TreePointSearch::Dimensionality, MemorySpace> dimensionalities;
+	Rank1View<LO, MemorySpace> element_ids;
+	Rank2View<Real, MemorySpace> parametric_coords;
 };
 
 } // namespace detail

--- a/src/pcms/localization/point_localization.h
+++ b/src/pcms/localization/point_localization.h
@@ -15,33 +15,25 @@
 
 #include "pcms/utility/assert.h"
 #include "pcms/utility/types.h"
+#include "pcms/utility/arrays.h"
 #include "pcms/field/coordinate_system.h"
 
 namespace pcms
 {
 
-template <int dim>
-class Mapping
+class Mapping2D
 {
 public:
-	static constexpr int DIM = dim;
-	virtual Omega_h::Vector<DIM + 1> get_bary(Omega_h::Vector<DIM> const& p) const = 0;
-	virtual int which(int ent_dim, 
-					  Omega_h::Vector<DIM + 1> const& bary_coords) const = 0;
-};
-
-// Two dimensional mapping class
-// Constructs a mapping of any point in global space to
-// the barycentric coordinate system of a given triangle
-class Mapping2D : public Mapping<2>
-{
-public:
+	static constexpr int DIM = 2;
+	using MemorySpace = Omega_h::ExecSpace::memory_space;
 	Mapping2D() = default;
 	Mapping2D(int elem_index, Omega_h::Mesh const& mesh);
 	~Mapping2D() = default;
-	Omega_h::Vector<DIM + 1> get_bary(Omega_h::Vector<DIM> const& p) const override;
+	KOKKOS_FUNCTION
+	Omega_h::Vector<DIM + 1> get_bary(Omega_h::Vector<DIM> const& p) const;
+	KOKKOS_FUNCTION
 	int which(int ent_dim, 
-					  Omega_h::Vector<DIM + 1> const& bary_coords) const override;
+					  Omega_h::Vector<DIM + 1> const& bary_coords) const;
 private:
 	// helpers
 	int which_vert(Omega_h::Vector<DIM + 1> const& bary_coords) const;
@@ -55,15 +47,19 @@ private:
 	double triangle_area;
 };
 
-class Mapping3D : public Mapping<3>
+class Mapping3D
 {
 public:
+	static constexpr int DIM = 3;
+	using MemorySpace = Omega_h::ExecSpace::memory_space;
 	Mapping3D() = default;
 	Mapping3D(int elem_index, Omega_h::Mesh const& mesh);
 	~Mapping3D() = default;
-	Omega_h::Vector<DIM + 1> get_bary(Omega_h::Vector<DIM> const& p) const override;
+	KOKKOS_FUNCTION
+	Omega_h::Vector<DIM + 1> get_bary(Omega_h::Vector<DIM> const& p) const;
+	KOKKOS_FUNCTION
 	int which(int ent_dim, 
-					  Omega_h::Vector<DIM+1> const& bary_coords) const override;
+					  Omega_h::Vector<DIM+1> const& bary_coords) const;
 private:
 	// helpers
 	int which_vert(Omega_h::Vector<DIM+1> const& bary_coords) const;
@@ -87,10 +83,43 @@ private:
 	static const char OFFSETS = 1 << 4 | 3 << 2 | 2;
 };
 
+struct TreeWrapper
+{
+	virtual void* get_tree() = 0;
+	virtual void* get_mappings() = 0;
+};
+struct TreeWrapper2D : TreeWrapper
+{
+	using Mappings_t = Kokkos::View<Mapping2D*, Omega_h::ExecSpace::memory_space>;
+	using Tree_t = ArborX::BVH<Omega_h::ExecSpace::memory_space,
+			ArborX::PairValueIndex<ArborX::Box<2, double>, unsigned>>;
+	
+	TreeWrapper2D(const Mappings_t& mappings, const Tree_t& tree) : mappings_(mappings), tree_(tree) {}
+	~TreeWrapper2D() = default;
+	void* get_tree() override { return &tree_; };
+	void* get_mappings() override {return &mappings_; };
+private:
+	Tree_t tree_;
+	Mappings_t mappings_;
+};
+struct TreeWrapper3D : TreeWrapper
+{
+	using Mappings_t = Kokkos::View<Mapping3D*, Omega_h::ExecSpace::memory_space>;
+	using Tree_t = ArborX::BVH<Omega_h::ExecSpace::memory_space,
+			ArborX::PairValueIndex<ArborX::Box<3, double>, unsigned>>;
+
+	TreeWrapper3D(const Mappings_t& mappings, const Tree_t& tree) : mappings_(mappings), tree_(tree) {}
+	~TreeWrapper3D() = default;
+	void* get_tree() override { return &tree_; };
+	void* get_mappings() override {return &mappings_; };
+private:
+	Tree_t tree_;
+	Mappings_t mappings_;
+};
+
 /**
  * Point search base class
  */
-template <int dim>
 class PointSearch
 {
 public:
@@ -103,60 +132,40 @@ public:
 			VERTEX = 0,
 			EDGE = 1,
 			FACE = 2,
-			REGION = 3
+			REGION = 3,
+			NO_INTERSECT = 4
 		};
 
 		Dimensionality dimensionality;
 		LO element_id;
-		Omega_h::Vector<dim + 1> parametric_coords;
+		Omega_h::Vector<4> parametric_coords;
 	};
 
-	static constexpr auto DIM = dim;
-	
 	PointSearch() = default;
 	~PointSearch() = default;
 	virtual Kokkos::View<Result*> apply(const CoordinateView<MemorySpace>& coords) const = 0;
 };
 
-using PointSearch2D = PointSearch<2>;
-using PointSearch3D = PointSearch<3>;
-
-class TreePointSearch2D : public PointSearch2D
+class TreePointSearch : public PointSearch
 {
 public:
-	using Result_t = PointSearch2D::Result;
-	using Dim_t = Result_t::Dimensionality;
-	TreePointSearch2D(const Omega_h::Mesh& mesh);
-	Kokkos::View<Result_t*> apply(
+	using Result = PointSearch::Result;
+	using Dimensionality = Result::Dimensionality;
+	using ExecSpace = PointSearch::ExecSpace;
+	using MemorySpace = PointSearch::MemorySpace;
+	TreePointSearch(const Omega_h::Mesh& mesh);
+	~TreePointSearch() = default;
+	Kokkos::View<Result*> apply(
 		const CoordinateView<Omega_h::ExecSpace::memory_space>& coords) const override;
 private:
+	std::unique_ptr<TreeWrapper> make_tree(const Omega_h::Mesh& mesh) const;
+	KOKKOS_INLINE_FUNCTION Mapping2D get_mapping2D(LO i) const 
+	{ return ((TreeWrapper2D::Mappings_t*)tree->get_mappings())->operator()(i); };
+	KOKKOS_INLINE_FUNCTION Mapping3D get_mapping3D(LO i) const 
+	{ return ((TreeWrapper3D::Mappings_t*)tree->get_mappings())->operator()(i); };
 	// Reference to the input mesh
 	Omega_h::Mesh const &mesh_;
-	// Mapping for each triangle in the mesh
-	// (TODO find way to make these the leaf nodes of the tree)
-	Kokkos::View<Mapping2D*> mappings;
-	// Bounding Volume Hierarchy of input mesh
-	ArborX::BVH<Omega_h::ExecSpace::memory_space,
-				ArborX::PairValueIndex<ArborX::Box<2, double>, unsigned>> tree;
-};
-
-class TreePointSearch3D : public PointSearch3D
-{
-public:
-	using Result_t = PointSearch3D::Result;
-	using Dim_t = Result_t::Dimensionality;
-	TreePointSearch3D(const Omega_h::Mesh& mesh);
-	Kokkos::View<Result_t*> apply(
-		const CoordinateView<Omega_h::ExecSpace::memory_space>& coords) const override;
-private:
-	// Reference to the input mesh
-	Omega_h::Mesh const &mesh_;
-	// Mapping for each triangle in the mesh
-	// (TODO find way to make these the leaf nodes of the tree)
-	Kokkos::View<Mapping3D*> mappings;
-	// Bounding Volume Hierarchy of input mesh
-	ArborX::BVH<Omega_h::ExecSpace::memory_space,
-				ArborX::PairValueIndex<ArborX::Box<3, double>, unsigned>> tree;
+	std::unique_ptr<TreeWrapper> tree;
 };
 
 } // namespace pcms

--- a/src/pcms/localization/point_localization.h
+++ b/src/pcms/localization/point_localization.h
@@ -140,5 +140,24 @@ private:
 				ArborX::PairValueIndex<ArborX::Box<2, double>, unsigned>> tree;
 };
 
+class TreePointSearch3D : public PointSearch3D
+{
+public:
+	using Result_t = PointSearch3D::Result;
+	using Dim_t = Result_t::Dimensionality;
+	TreePointSearch3D(const Omega_h::Mesh& mesh);
+	Kokkos::View<Result_t*> apply(
+		const CoordinateView<Omega_h::ExecSpace::memory_space>& coords) const override;
+private:
+	// Reference to the input mesh
+	Omega_h::Mesh const &mesh_;
+	// Mapping for each triangle in the mesh
+	// (TODO find way to make these the leaf nodes of the tree)
+	Kokkos::View<Mapping3D*> mappings;
+	// Bounding Volume Hierarchy of input mesh
+	ArborX::BVH<Omega_h::ExecSpace::memory_space,
+				ArborX::PairValueIndex<ArborX::Box<3, double>, unsigned>> tree;
+};
+
 } // namespace pcms
 #endif // POINT_LOCALIZATION_H

--- a/src/pcms/localization/point_localization.h
+++ b/src/pcms/localization/point_localization.h
@@ -1,0 +1,144 @@
+#ifndef POINT_LOCALIZATION_H
+#define POINT_LOCALIZATION_H
+
+#include <ArborX.hpp>
+#include <ArborX_Triangle.hpp>
+#include <detail/ArborX_PairValueIndex.hpp>
+#include <detail/ArborX_AttachIndices.hpp>
+
+#include <Kokkos_Core.hpp>
+#include <Omega_h_mesh.hpp>
+#include <Omega_h_bbox.hpp>
+#include <Omega_h_shape.hpp>
+#include <Omega_h_matrix.hpp>
+#include <Omega_h_simplex.hpp>
+
+#include "pcms/utility/assert.h"
+#include "pcms/utility/types.h"
+#include "pcms/field/coordinate_system.h"
+
+namespace pcms
+{
+
+template <int dim>
+class Mapping
+{
+public:
+	static constexpr int DIM = dim;
+	virtual Omega_h::Vector<DIM + 1> get_bary(Omega_h::Vector<DIM> const& p) const = 0;
+	virtual int which(int ent_dim, 
+					  Omega_h::Vector<DIM + 1> const& bary_coords) const = 0;
+};
+
+// Two dimensional mapping class
+// Constructs a mapping of any point in global space to
+// the barycentric coordinate system of a given triangle
+class Mapping2D : public Mapping<2>
+{
+public:
+	Mapping2D() = default;
+	Mapping2D(int elem_index, Omega_h::Mesh const& mesh);
+	~Mapping2D() = default;
+	Omega_h::Vector<DIM + 1> get_bary(Omega_h::Vector<DIM> const& p) const override;
+	int which(int ent_dim, 
+					  Omega_h::Vector<DIM + 1> const& bary_coords) const override;
+private:
+	// helpers
+	int which_vert(Omega_h::Vector<DIM + 1> const& bary_coords) const;
+	int which_edge(Omega_h::Vector<DIM + 1> const& bary_coords) const;
+	int within_elem(Omega_h::Vector<DIM + 1> const& bary_coords) const;
+	void set_mesh_triangle(int index, Omega_h::Mesh const& mesh);
+	double opposite_edge_len_sq(int i) const;
+	// representation
+	Omega_h::Matrix<DIM,DIM> bary_transform; // Column-major order
+	Omega_h::Matrix<DIM,DIM + 1> triangle;
+	double triangle_area;
+};
+
+class Mapping3D : public Mapping<3>
+{
+public:
+	Mapping3D() = default;
+	Mapping3D(int elem_index, Omega_h::Mesh const& mesh);
+	~Mapping3D() = default;
+	Omega_h::Vector<DIM + 1> get_bary(Omega_h::Vector<DIM> const& p) const override;
+	int which(int ent_dim, 
+					  Omega_h::Vector<DIM+1> const& bary_coords) const override;
+private:
+	// helpers
+	int which_vert(Omega_h::Vector<DIM+1> const& bary_coords) const;
+	int which_edge(Omega_h::Vector<DIM+1> const& bary_coords) const;
+	int which_face(Omega_h::Vector<DIM+1> const& bary_coords) const;
+	int within_elem(Omega_h::Vector<DIM+1> const& bary_coords) const;
+	void set_mesh_tet(int index, Omega_h::Mesh const& mesh);
+	void set_triangle_areas();
+	// returns the actual face/edge offset from the barycentric offset
+	KOKKOS_INLINE_FUNCTION int face(int i) const 
+	{ return (OFFSETS & 3 << (i*2))>>(i*2);}
+	KOKKOS_INLINE_FUNCTION int edge(int i) const 
+	{ return (i < 4 && i > 0) ? (OFFSETS & 3 << ((i-1)*2))>>((i-1)*2) : i; }
+	// representation
+	Omega_h::Matrix<DIM,DIM> bary_transform; // Column-major order
+	Omega_h::Matrix<DIM,DIM+1> tetrahedron;
+	Omega_h::Vector<DIM+1> face_areas;
+	double tetrahedron_volume;
+	// This is used to calculate the face and edge offsets in the cannonical ordering: 
+	// https://user-images.githubusercontent.com/56453280/74203616-39d27a80-4c3e-11ea-885d-b0260490e184.png
+	static const char OFFSETS = 1 << 4 | 3 << 2 | 2;
+};
+
+/**
+ * Point search base class
+ */
+template <int dim>
+class PointSearch
+{
+public:
+	using ExecSpace = Omega_h::ExecSpace;
+	using MemorySpace = ExecSpace::memory_space;
+	struct Result
+	{
+		enum class Dimensionality
+		{
+			VERTEX = 0,
+			EDGE = 1,
+			FACE = 2,
+			REGION = 3
+		};
+
+		Dimensionality dimensionality;
+		LO element_id;
+		Omega_h::Vector<dim + 1> parametric_coords;
+	};
+
+	static constexpr auto DIM = dim;
+	
+	PointSearch() = default;
+	~PointSearch() = default;
+	virtual Kokkos::View<Result*> apply(const CoordinateView<MemorySpace>& coords) const = 0;
+};
+
+using PointSearch2D = PointSearch<2>;
+using PointSearch3D = PointSearch<3>;
+
+class TreePointSearch2D : public PointSearch2D
+{
+public:
+	using Result_t = PointSearch2D::Result;
+	using Dim_t = Result_t::Dimensionality;
+	TreePointSearch2D(const Omega_h::Mesh& mesh);
+	Kokkos::View<Result_t*> apply(
+		const CoordinateView<Omega_h::ExecSpace::memory_space>& coords) const override;
+private:
+	// Reference to the input mesh
+	Omega_h::Mesh const &mesh_;
+	// Mapping for each triangle in the mesh
+	// (TODO find way to make these the leaf nodes of the tree)
+	Kokkos::View<Mapping2D*> mappings;
+	// Bounding Volume Hierarchy of input mesh
+	ArborX::BVH<Omega_h::ExecSpace::memory_space,
+				ArborX::PairValueIndex<ArborX::Box<2, double>, unsigned>> tree;
+};
+
+} // namespace pcms
+#endif // POINT_LOCALIZATION_H

--- a/src/pcms/localization/point_localization.h
+++ b/src/pcms/localization/point_localization.h
@@ -298,7 +298,7 @@ private:
 	void set_triangle_areas();
 	// returns the actual face/edge offset from the barycentric offset
 	KOKKOS_INLINE_FUNCTION int face(int i) const 
-	{ return (OFFSETS & 3 << (i*2))>>(i*2);}
+	{ return (OFFSETS & 3 << (i*2))>>(i*2); }
 	KOKKOS_INLINE_FUNCTION int edge(int i) const 
 	{ return (i < 4 && i > 0) ? (OFFSETS & 3 << ((i-1)*2))>>((i-1)*2) : i; }
 	// representation

--- a/src/pcms/localization/point_localization.h
+++ b/src/pcms/localization/point_localization.h
@@ -21,29 +21,148 @@
 namespace pcms
 {
 
+namespace detail
+{
+
+/**
+* @brief Implementation of the Kronecker delta:
+*		 https://en.wikipedia.org/wiki/Kronecker_delta
+* @param i an integer
+* @param j another integer
+* @returns 1 if i==j, 0 if i i!= j
+*/
+KOKKOS_INLINE_FUNCTION
+LO kronecker(LO i, LO j) { return (LO)(i==j); }
+
+/**
+* @brief Omega_h::Mesh tagged with the templated dimension required for 
+*		 compatability with ArborX::BVH
+*/
+template <int dim>
+struct Omega_h_Mesh_Adapt
+{
+	const Omega_h::LO size_;
+	const Omega_h::LOs adjacency;
+	const Omega_h::Reals coordinates;
+};
+
+/**
+* @brief pcms CoordinateView tagged with the templated dimension and 
+*		 memory space required for compatability with ArborX::BVH
+*/
+template <typename MemorySpace, int dim>
+struct Coordinate_View_Adapt
+{
+	const Rank2View<const Real, MemorySpace, default_layout_for_memory_space_t<MemorySpace>> points;
+};
+
+/**
+* @brief Mapping2D represents a mapping from the global coordinate system
+*		 to the barycentric coordinate system of an element in a 2D Omega_h::Mesh
+* The class Mapping2D calculates the mapping of any point in global coordinate
+* space to the barycentric coordinate space belonging to a triangle (face) in
+* an Omega_h::Mesh.
+* An instance of Mapping2D can, from the barycentric coordinates constructed by it,
+* determine whether that point intersects the face, an edge, a vertex, or lies 
+* outside the face. It also determines which edge or vertex the point intersects
+* by calculating the offset in the Omega_h::Adj::ab2b
+*/
 class Mapping2D
 {
 public:
+	// the dimension of the space
 	static constexpr int DIM = 2;
-	using MemorySpace = Omega_h::ExecSpace::memory_space;
+	// CONSTRUCTORS
+	/**
+	* @brief Default constructor
+	*/
+	KOKKOS_FUNCTION
 	Mapping2D() = default;
+	/**
+	* @brief Constructs a barycentric mapping of a triangle in an Omega_h::Mesh
+	* @param elem_index the index of the desired triangle or tetrahedron in the Omega_h::Mesh
+	* @param mesh the Omega_h::Mesh with the spatial information of the triangle
+	*/
 	Mapping2D(int elem_index, Omega_h::Mesh const& mesh);
+	/**
+	* @brief Default destructor
+	*/
+	KOKKOS_FUNCTION
 	~Mapping2D() = default;
+	/**
+	* @brief Computes the barycentric coordinates of a point in global space
+	*
+	* This function computes the barycentric coordinate of a point with respect
+	* to a triangle in an Omega_h::Mesh
+	*
+	* @param p the point to compute the barycentric coordinates of
+	* @returns an Omega_h::Vector<3> containing the barycentric coordinates
+	* 		   of p
+	*/
 	KOKKOS_FUNCTION
 	Omega_h::Vector<DIM + 1> get_bary(Omega_h::Vector<DIM> const& p) const;
+	/**
+	* @brief Determines which entity of a particular dimension a point intersects
+	*		 from the barycentric coordinates
+	* 
+	* This function determines the offset in the Omega_h::Adj structure
+	*/
 	KOKKOS_FUNCTION
-	int which(int ent_dim, 
-					  Omega_h::Vector<DIM + 1> const& bary_coords) const;
+	int which(
+		int ent_dim, 
+		Omega_h::Vector<DIM + 1> const& bary_coords) const;
 private:
-	// helpers
+	/**
+	* @brief Computes the vertex offset of the point corresponding 
+	* 		  to the input barycentric coordinates
+	* @param bary_coords the input barycentric coordinates
+	* @returns the vertex offset if the point corresponding to the given bary. coordinates
+	* 			is within a certain (global) tolerance of a vertex
+	* 			-1 if the point does not lie within the tolerance of any vertex
+	*/
+	KOKKOS_FUNCTION
 	int which_vert(Omega_h::Vector<DIM + 1> const& bary_coords) const;
+	/**
+	* @brief Computes the edge offset of the point corresponding 
+	* 		 to the input barycentric coordinates
+	* @param bary_coords the input barycentric coordinates
+	* @returns the edge offset if the distnce from the point corresponding to the 
+	* 			given bary. coordinates to the edge with the respective offset
+	* 			is within a certain (global) tolerance
+	* 			-1 if the point does not lie within the tolerance of any vertex
+	*/
+	KOKKOS_FUNCTION
 	int which_edge(Omega_h::Vector<DIM + 1> const& bary_coords) const;
+	/**
+	* @brief Computes whether a point with the given barycentric coordinates
+	* 		  is within a triangle
+	* @param bary_coords the input barycentric coordinates
+	* @returns 0 if the point is within the highest order element and -1 otherwise
+	*/
+	KOKKOS_FUNCTION
 	int within_elem(Omega_h::Vector<DIM + 1> const& bary_coords) const;
+	/**
+	* @brief Constructs the triangle the mapping corresponds to
+	* @param index the element ID of the triangle
+	* @param mesh the Omega_h::Mesh with the spatial information for the triangle
+	* 			   corresponding to index
+	*/
 	void set_mesh_triangle(int index, Omega_h::Mesh const& mesh);
+	/**
+	* @brief Calculates the length of the edge opposite vertex i
+	* @param i the vertex index opposite the desired edge
+	* @returns the length of the ith edge
+	*/
+	KOKKOS_FUNCTION
 	double opposite_edge_len_sq(int i) const;
-	// representation
+	
+	// REPRESENTATION
+	// representation of the barycentric coordinate mapping, source:
+	// https://en.wikipedia.org/wiki/Barycentric_coordinate_system#Edge_approach
 	Omega_h::Matrix<DIM,DIM> bary_transform; // Column-major order
+	// Points defining the triangle
 	Omega_h::Matrix<DIM,DIM + 1> triangle;
+	// area of the triangle
 	double triangle_area;
 };
 
@@ -51,21 +170,81 @@ class Mapping3D
 {
 public:
 	static constexpr int DIM = 3;
-	using MemorySpace = Omega_h::ExecSpace::memory_space;
+	/**
+	* @brief Default constructor
+	*/
+	KOKKOS_FUNCTION
 	Mapping3D() = default;
+	/**
+	* @brief Constructs a barycentric mapping of a triangle in an Omega_h::Mesh
+	* @param elem_index the index of the desired triangle or tetrahedron in the Omega_h::Mesh
+	* @param mesh the Omega_h::Mesh with the spatial information of the triangle
+	*/
 	Mapping3D(int elem_index, Omega_h::Mesh const& mesh);
+	/**
+	* @brief Default destructor
+	*/
+	KOKKOS_FUNCTION
 	~Mapping3D() = default;
+	/**
+	* @brief Computes the barycentric coordinates of a point in global space
+	* @param p the point to compute the barycentric coordinates of
+	* @returns an Omega_h::Vector<dim + 1> containing the barycentric coordinates
+	* 			of p
+	*/
 	KOKKOS_FUNCTION
 	Omega_h::Vector<DIM + 1> get_bary(Omega_h::Vector<DIM> const& p) const;
+
 	KOKKOS_FUNCTION
 	int which(int ent_dim, 
 					  Omega_h::Vector<DIM+1> const& bary_coords) const;
-private:
-	// helpers
+private:	
+	/**
+	* @brief Computes the vertex offset of the point corresponding 
+	*		 to the input barycentric coordinates
+	* @param bary_coords the input barycentric coordinates
+	* @returns the vertex offset if the point corresponding to the given bary. coordinates
+	* 		   is within a certain (global) tolerance of a vertex
+	* 		   -1 if the point does not lie within the tolerance of any vertex
+	*/
+	KOKKOS_FUNCTION
 	int which_vert(Omega_h::Vector<DIM+1> const& bary_coords) const;
+	/**
+	* @brief Computes the edge offset of the point corresponding 
+	* 		 to the input barycentric coordinates
+	* @param bary_coords the input barycentric coordinates
+	* @returns the edge offset if the distnce from the point corresponding to the
+	* 		   given bary. coordinates to the edge with the respective offset
+	* 		   is within a certain (global) tolerance
+	* 		   -1 if the point does not lie within the tolerance of any vertex
+	*/
+	KOKKOS_FUNCTION
 	int which_edge(Omega_h::Vector<DIM+1> const& bary_coords) const;
+	/**
+	* @brief Computes the face offset of the point corresponding 
+	* 		 to the input barycentric coordinates
+	* @param bary_coords the input barycentric coordinates
+	* @returns if the point corresponding to the bary. coords is within a 
+	* 		   global tolerance of a face, returns the offset of that face
+	* 		   -1 if the point does not lie within the tolerance of any face
+	* Algorithm source:
+	* C.E. Passerello,
+	* Interference detection using barycentric coordinates,
+	* Mechanics Research Communications,
+	* Volume 9, Issue 6, 1982, Pages 373-378,
+	* https://doi.org/10.1016/0093-6413(82)90034-9.
+	*/
+	KOKKOS_FUNCTION
 	int which_face(Omega_h::Vector<DIM+1> const& bary_coords) const;
+	/**
+	* @brief Computes whether a point with the given barycentric coordinates
+	* 		  is within a triangle
+	* @param bary_coords the input barycentric coordinates
+	* @returns 0 if the point is within the highet order element and -1 otherwise
+	*/
+	KOKKOS_FUNCTION
 	int within_elem(Omega_h::Vector<DIM+1> const& bary_coords) const;
+	
 	void set_mesh_tet(int index, Omega_h::Mesh const& mesh);
 	void set_triangle_areas();
 	// returns the actual face/edge offset from the barycentric offset
@@ -88,6 +267,7 @@ struct TreeWrapper
 	virtual void* get_tree() = 0;
 	virtual void* get_mappings() = 0;
 };
+
 struct TreeWrapper2D : TreeWrapper
 {
 	using Mappings_t = Kokkos::View<Mapping2D*, Omega_h::ExecSpace::memory_space>;
@@ -102,6 +282,7 @@ private:
 	Tree_t tree_;
 	Mappings_t mappings_;
 };
+
 struct TreeWrapper3D : TreeWrapper
 {
 	using Mappings_t = Kokkos::View<Mapping3D*, Omega_h::ExecSpace::memory_space>;
@@ -117,6 +298,7 @@ private:
 	Mappings_t mappings_;
 };
 
+} //namespace detail
 /**
  * Point search base class
  */
@@ -153,20 +335,139 @@ public:
 	using Dimensionality = Result::Dimensionality;
 	using ExecSpace = PointSearch::ExecSpace;
 	using MemorySpace = PointSearch::MemorySpace;
-	TreePointSearch(const Omega_h::Mesh& mesh);
+	TreePointSearch(const Omega_h::Mesh& mesh) : mesh_(mesh), tree(make_tree(mesh)) {}
 	~TreePointSearch() = default;
 	Kokkos::View<Result*> apply(
-		const CoordinateView<Omega_h::ExecSpace::memory_space>& coords) const override;
+		const CoordinateView<MemorySpace>& coords) const override;
 private:
-	std::unique_ptr<TreeWrapper> make_tree(const Omega_h::Mesh& mesh) const;
-	KOKKOS_INLINE_FUNCTION Mapping2D get_mapping2D(LO i) const 
-	{ return ((TreeWrapper2D::Mappings_t*)tree->get_mappings())->operator()(i); };
-	KOKKOS_INLINE_FUNCTION Mapping3D get_mapping3D(LO i) const 
-	{ return ((TreeWrapper3D::Mappings_t*)tree->get_mappings())->operator()(i); };
+	std::unique_ptr<detail::TreeWrapper> make_tree(const Omega_h::Mesh& mesh) const;
 	// Reference to the input mesh
 	Omega_h::Mesh const &mesh_;
-	std::unique_ptr<TreeWrapper> tree;
+	std::unique_ptr<detail::TreeWrapper> tree;
 };
+
+namespace detail
+{
+
+class CallOnIntersect3D
+{
+public:
+	using MemorySpace = TreePointSearch::MemorySpace;
+	static constexpr int DIM = 3;
+
+	CallOnIntersect3D(
+		const Kokkos::View<Mapping3D*, MemorySpace>& mappings_,
+		const Omega_h::LOs& adjacencies0,
+		const Omega_h::LOs& adjacencies1,
+		const Omega_h::LOs& adjacencies2,
+		const Kokkos::View<TreePointSearch::Result*, MemorySpace>& intersection_results_
+	) : mappings(mappings_),  
+		intersection_results(intersection_results_)
+	{
+		adjacencies[0] = adjacencies0;
+		adjacencies[1] = adjacencies1;
+		adjacencies[2] = adjacencies2;
+	};
+	
+	template <typename Predicate, typename Value>
+	KOKKOS_FUNCTION void operator()(Predicate const &predicate, Value const & val) const
+	{
+		ArborX::Point<DIM, Omega_h::Real> const& ax = ArborX::getGeometry(predicate);
+		Omega_h::Vector<DIM> point{ax[0], ax[1], ax[2]};
+		int point_ind = ArborX::getData(predicate);
+		
+		detail::Mapping3D const& tm = mappings(val.index);
+		
+		// calculate the barycentric coefficients of the point
+		auto coeffs = tm.get_bary(point);
+		int offsets[DIM] = {4, 6, 4};
+		for (int i = 0; i < DIM; i++)
+		{
+			int elem = tm.which(i, coeffs);
+			if (elem >= 0 && intersection_results(point_ind).dimensionality > (TreePointSearch::Dimensionality)i)
+			{
+				auto elem_ind = adjacencies[i][offsets[i]*val.index + elem];
+				intersection_results(point_ind).dimensionality = (TreePointSearch::Dimensionality)i;
+				intersection_results(point_ind).element_id = elem_ind;
+				for (int j = 0; j < DIM + 1; j++)
+					intersection_results(point_ind).parametric_coords(j) = coeffs[j];
+				return;
+			}
+		}
+
+		if (tm.which(DIM, coeffs) >= 0 
+				&& intersection_results(point_ind).dimensionality >= TreePointSearch::Dimensionality::REGION)
+		{
+			intersection_results(point_ind).dimensionality = TreePointSearch::Dimensionality::REGION;
+			intersection_results(point_ind).element_id = (LO)val.index;
+			for (int j = 0; j < DIM + 1; j++)
+					intersection_results(point_ind).parametric_coords(j) = coeffs[j];
+		}
+	}
+private:
+	Kokkos::View<Mapping3D*, MemorySpace> mappings;
+	Omega_h::LOs adjacencies[3];
+	Kokkos::View<TreePointSearch::Result*, MemorySpace> intersection_results;
+};
+
+class CallOnIntersect2D
+{
+public:
+	using MemorySpace = TreePointSearch::MemorySpace;
+	static constexpr int DIM = 2;
+
+	CallOnIntersect2D(
+		const Kokkos::View<Mapping2D*, MemorySpace>& mappings_,
+		const Omega_h::LOs& adjacencies0,
+		const Omega_h::LOs& adjacencies1,
+		const Kokkos::View<TreePointSearch::Result*, MemorySpace>& intersection_results_
+	) : mappings(mappings_),  
+		intersection_results(intersection_results_)
+	{
+		adjacencies[0] = adjacencies0;
+		adjacencies[1] = adjacencies1;
+	};
+	
+	template <typename Predicate, typename Value>
+	KOKKOS_FUNCTION void operator()(Predicate const &predicate, Value const & val) const
+	{
+		ArborX::Point<DIM, Omega_h::Real> const& ax = ArborX::getGeometry(predicate);
+		Omega_h::Vector<DIM> point{ax[0], ax[1]};
+		int point_ind = ArborX::getData(predicate);
+		
+		detail::Mapping2D const& tm = mappings(val.index);
+		
+		// calculate the barycentric coefficients of the point
+		auto coeffs = tm.get_bary(point);
+
+		for (int i = 0; i < DIM; i++)
+		{
+			int elem = tm.which(i, coeffs);
+			if (elem >= 0 && intersection_results(point_ind).dimensionality > (TreePointSearch::Dimensionality)i)
+			{
+				auto elem_ind = adjacencies[i][3*val.index + elem];
+				intersection_results(point_ind).dimensionality = (TreePointSearch::Dimensionality)i;
+				intersection_results(point_ind).element_id = elem_ind;
+				for (int j = 0; j < DIM + 1; j++)
+					intersection_results(point_ind).parametric_coords(j) = coeffs[j];
+				return;
+			}
+		}
+		if (tm.which(DIM, coeffs) >= 0 
+			&& intersection_results(point_ind).dimensionality > TreePointSearch::Dimensionality::FACE)
+		{
+			intersection_results(point_ind).dimensionality = TreePointSearch::Dimensionality::FACE;
+			intersection_results(point_ind).element_id = (LO)val.index;
+			for (int j = 0; j < DIM + 1; j++)
+					intersection_results(point_ind).parametric_coords(j) = coeffs[j];
+		}
+	}
+private:
+	Kokkos::View<Mapping2D*, MemorySpace> mappings;
+	Omega_h::LOs adjacencies[2];
+	Kokkos::View<TreePointSearch::Result*, MemorySpace> intersection_results;
+};
+} // namespace detail
 
 } // namespace pcms
 #endif // POINT_LOCALIZATION_H

--- a/src/pcms/localization/point_localization.h
+++ b/src/pcms/localization/point_localization.h
@@ -18,7 +18,6 @@
 #include "pcms/utility/assert.h"
 #include "pcms/utility/types.h"
 #include "pcms/utility/arrays.h"
-#include "pcms/field/coordinate_system.h"
 #include "pcms/localization/point_search.h"
 
 namespace pcms
@@ -365,66 +364,6 @@ private:
 	std::shared_ptr<std::any> mappings_;
 };
 } //namespace detail
-
-/**
- * Point search base class
- */
-class PointSearch
-{
-public:
-	using ExecSpace = Omega_h::ExecSpace;
-	using MemorySpace = ExecSpace::memory_space;
-	/**
-	* Results type gives dimensionalities of point intersection, the intersected
-	* element IDs, and the barycentric coordinate mappings of each point as follows:
-	* the `i`th input point has intersection dimensionality of 
-	* `dimensionalities(i)`, intersected element ID of `element_ids(i)`, and 
-	* likewise parametric coordinate mapping of `parametric_coords(i,0..d)`
-	* where `d` is the dimension of the space
-	*/
-	struct Results
-	{
-		enum class Dimensionality
-		{
-			VERTEX = 0,
-			EDGE = 1,
-			FACE = 2,
-			REGION = 3,
-			NO_INTERSECT = 4
-		};
-
-		Kokkos::View<Dimensionality*, MemorySpace> dimensionalities;
-		Kokkos::View<LO*, MemorySpace> element_ids;
-		Kokkos::View<Real**, MemorySpace> parametric_coords;
-	};
-
-	using PointSearchTolerances = Kokkos::View<Real*>;
-
-	explicit PointSearch(const PointSearchTolerances& tolerances)
-		: tolerances_(tolerances)
-	{
-		assert(tolerances_.is_allocated());
-	}
-
-	~PointSearch() = default;
-
-	virtual Results apply(const CoordinateView<MemorySpace>& coords) const = 0;
-	/**
-	* This function provides a temporary solution to retrieve the original
-	* behavior of the point search, which previously returned the face ID
-	* regardless of which entity the search result belonged to. Many parts of
-	* the codebase still rely on this legacy behavior. After updating the point
-	* search to return the exact entity, this function can be called to retrieve
-	* the old behavior and ensure correctness. Long term, the implementation
-	* should be updated to properly handle the new result.
-	*/
-	[[nodiscard]] virtual LO GetOwningElementId(const Results& results, int i) = 0;
-	[[nodiscard]] virtual Kokkos::View<LO*> GetOwningElementIds(
-		const Results& results) = 0;
-protected:
-	PointSearchTolerances tolerances_;
-};
-
 
 class TreePointSearch : public PointSearch
 {

--- a/src/pcms/localization/point_localization.h
+++ b/src/pcms/localization/point_localization.h
@@ -1,6 +1,8 @@
 #ifndef POINT_LOCALIZATION_H
 #define POINT_LOCALIZATION_H
 
+#include <any>
+
 #include <ArborX.hpp>
 #include <ArborX_Triangle.hpp>
 #include <detail/ArborX_PairValueIndex.hpp>
@@ -56,18 +58,22 @@ struct Coordinate_View_Adapt
 	const Rank2View<const Real, MemorySpace, default_layout_for_memory_space_t<MemorySpace>> points;
 };
 
+template <int dim>
+class Mapping {};
+
 /**
-* @brief Mapping2D represents a mapping from the global coordinate system
+* @brief Mapping<2> represents a mapping from the global coordinate system
 *		 to the barycentric coordinate system of an element in a 2D Omega_h::Mesh
-* The class Mapping2D calculates the mapping of any point in global coordinate
+* The class Mapping<2> calculates the mapping of any point in global coordinate
 * space to the barycentric coordinate space belonging to a triangle (face) in
 * an Omega_h::Mesh.
-* An instance of Mapping2D can, from the barycentric coordinates constructed by it,
+* An instance of Mapping<2> can, from the barycentric coordinates constructed by it,
 * determine whether that point intersects the face, an edge, a vertex, or lies 
 * outside the face. It also determines which edge or vertex the point intersects
 * by calculating the offset in the Omega_h::Adj::ab2b
 */
-class Mapping2D
+template <>
+class Mapping<2>
 {
 public:
 	// the dimension of the space
@@ -77,18 +83,18 @@ public:
 	* @brief Default constructor
 	*/
 	KOKKOS_FUNCTION
-	Mapping2D() = default;
+	Mapping() = default;
 	/**
 	* @brief Constructs a barycentric mapping of a triangle in an Omega_h::Mesh
 	* @param elem_index the index of the desired triangle or tetrahedron in the Omega_h::Mesh
 	* @param mesh the Omega_h::Mesh with the spatial information of the triangle
 	*/
-	Mapping2D(int elem_index, Omega_h::Mesh const& mesh);
+	Mapping(int elem_index, Omega_h::Mesh const& mesh);
 	/**
 	* @brief Default destructor
 	*/
 	KOKKOS_FUNCTION
-	~Mapping2D() = default;
+	~Mapping() = default;
 	/**
 	* @brief Computes the barycentric coordinates of a point in global space
 	*
@@ -178,7 +184,8 @@ private:
 	double triangle_area;
 };
 
-class Mapping3D
+template <>
+class Mapping<3>
 {
 public:
 	static constexpr int DIM = 3;
@@ -186,18 +193,18 @@ public:
 	* @brief Default constructor
 	*/
 	KOKKOS_FUNCTION
-	Mapping3D() = default;
+	Mapping() = default;
 	/**
 	* @brief Constructs a barycentric mapping of a triangle in an Omega_h::Mesh
 	* @param elem_index the index of the desired triangle or tetrahedron in the Omega_h::Mesh
 	* @param mesh the Omega_h::Mesh with the spatial information of the triangle
 	*/
-	Mapping3D(int elem_index, Omega_h::Mesh const& mesh);
+	Mapping(int elem_index, Omega_h::Mesh const& mesh);
 	/**
 	* @brief Default destructor
 	*/
 	KOKKOS_FUNCTION
-	~Mapping3D() = default;
+	~Mapping() = default;
 	/**
 	* @brief Computes the barycentric coordinates of a point in global space
 	* @param p the point to compute the barycentric coordinates of
@@ -227,7 +234,7 @@ public:
 	*/
 	KOKKOS_FUNCTION
 	int which(int ent_dim, 
-					  Omega_h::Vector<DIM+1> const& bary_coords) const;
+			  Omega_h::Vector<DIM+1> const& bary_coords) const;
 private:	
 	/**
 	* @brief Computes the vertex offset of the point corresponding 
@@ -310,86 +317,51 @@ private:
 */
 struct TreeWrapper
 {
+	template <int dim>
+	using Mappings_t = Kokkos::View<Mapping<dim>*, Omega_h::ExecSpace::memory_space>;
+	template <int dim>
+	using Tree_t = ArborX::BVH<Omega_h::ExecSpace::memory_space,
+			ArborX::PairValueIndex<ArborX::Box<dim, double>, unsigned>>;
+	
+	template <int dim>
+	TreeWrapper(const Mappings_t<dim>& mappings, const Tree_t<dim>& tree)
+	{
+		dim_ = dim;
+		mappings_ = std::make_shared<std::any>(mappings);
+		tree_ = std::make_shared<std::any>(tree);
+	}
 	/**
 	* @brief returns a pointer to an ArborX tree
 	*/
-	virtual void* get_tree() = 0;
+	template <int dim>
+	inline std::shared_ptr<Tree_t<dim>> get_tree()
+	{
+		if (dim != dim_)
+		{
+			throw pcms_error("Requested get_tree return "
+				"type does not match internal Tree_t");
+		}
+		return std::make_shared<Tree_t<dim>>(std::any_cast<Tree_t<dim>>(*tree_));
+	}
+
 	/**
 	* @brief returns a pointer to a Kokkos::View of Mappings
 	*/
-	virtual void* get_mappings() = 0;
-};
-
-/**
-* Wraper class for 2D ArborX::BVH and Mapping2D
-*/
-struct TreeWrapper2D : TreeWrapper
-{
-	/**
-	* typedefs for clarity in later code
-	*/
-	using Mappings_t = Kokkos::View<Mapping2D*, Omega_h::ExecSpace::memory_space>;
-	using Tree_t = ArborX::BVH<Omega_h::ExecSpace::memory_space,
-			ArborX::PairValueIndex<ArborX::Box<2, double>, unsigned>>;
-	
-	/**
-	* @brief Constructor, sets the View of Mappings and the tree
-	* @param mappings the mappings for every triangle in an Omega_h::Mesh
-	* @param tree an ArborX::BVH constructed fom an Omega_h::Mesh
-	*/
-	TreeWrapper2D(const Mappings_t& mappings, const Tree_t& tree) : mappings_(mappings), tree_(tree) {}
-	/**
-	* @brief default destructor
-	*/
-	~TreeWrapper2D() = default;
-	/**
-	* @brief Returns a pointer to the ArborX::BVH
-	*/
-	void* get_tree() override { return &tree_; };
-	/**
-	* @brief Returns a pointer to the Kokkos::View of Mapping2Ds
-	*/
-	void* get_mappings() override {return &mappings_; };
+	template <int dim>
+	inline std::shared_ptr<Mappings_t<dim>> get_mappings()
+	{
+		if (dim != dim_)
+		{
+			throw pcms_error("Requested get_mappings return "
+				"type does not match internal Mappings_t");
+		}
+		return std::make_shared<Mappings_t<dim>>(std::any_cast<Mappings_t<dim>>(*mappings_));
+	};
 private:
-	Tree_t tree_;
-	Mappings_t mappings_;
+	int dim_;
+	std::shared_ptr<std::any> tree_;
+	std::shared_ptr<std::any> mappings_;
 };
-
-/**
-* Wraper class for 3D ArborX::BVH and Mapping3D
-*/
-struct TreeWrapper3D : TreeWrapper
-{
-	/**
-	* typedefs for clarity in later code
-	*/
-	using Mappings_t = Kokkos::View<Mapping3D*, Omega_h::ExecSpace::memory_space>;
-	using Tree_t = ArborX::BVH<Omega_h::ExecSpace::memory_space,
-			ArborX::PairValueIndex<ArborX::Box<3, double>, unsigned>>;
-
-	/**
-	* @brief Constructor, sets the View of Mappings and the tree
-	* @param mappings the mappings for every triangle in an Omega_h::Mesh
-	* @param tree an ArborX::BVH constructed fom an Omega_h::Mesh
-	*/
-	TreeWrapper3D(const Mappings_t& mappings, const Tree_t& tree) : mappings_(mappings), tree_(tree) {}
-	/**
-	* @brief default destructor
-	*/
-	~TreeWrapper3D() = default;
-	/**
-	* @brief Returns a pointer to the ArborX::BVH
-	*/
-	void* get_tree() override { return &tree_; };
-	/**
-	* @brief Returns a pointer to the Kokkos::View of Mapping3Ds
-	*/
-	void* get_mappings() override {return &mappings_; };
-private:
-	Tree_t tree_;
-	Mappings_t mappings_;
-};
-
 } //namespace detail
 
 /**
@@ -437,6 +409,7 @@ public:
 	using Dimensionality = Result::Dimensionality;
 	using ExecSpace = PointSearch::ExecSpace;
 	using MemorySpace = PointSearch::MemorySpace;
+	
 	TreePointSearch(const Omega_h::Mesh& mesh) : mesh_(mesh), tree(make_tree(mesh)) {}
 	~TreePointSearch() = default;
 	/**
@@ -468,7 +441,7 @@ public:
 	static constexpr int DIM = 3;
 
 	CallOnIntersect3D(
-		const Kokkos::View<Mapping3D*, MemorySpace>& mappings_,
+		const Kokkos::View<Mapping<3>*, MemorySpace>& mappings_,
 		const Omega_h::LOs& adjacencies0,
 		const Omega_h::LOs& adjacencies1,
 		const Omega_h::LOs& adjacencies2,
@@ -487,7 +460,7 @@ public:
 	template <typename Predicate, typename Value>
 	KOKKOS_FUNCTION void operator()(Predicate const &predicate, Value const & val) const;
 private:
-	Kokkos::View<Mapping3D*, MemorySpace> mappings;
+	Kokkos::View<Mapping<3>*, MemorySpace> mappings;
 	Omega_h::LOs adjacencies[3];
 	Kokkos::View<TreePointSearch::Result*, MemorySpace> intersection_results;
 };
@@ -500,7 +473,7 @@ public:
 	static constexpr int DIM = 2;
 
 	CallOnIntersect2D(
-		const Kokkos::View<Mapping2D*, MemorySpace>& mappings_,
+		const Kokkos::View<Mapping<2>*, MemorySpace>& mappings_,
 		const Omega_h::LOs& adjacencies0,
 		const Omega_h::LOs& adjacencies1,
 		const Kokkos::View<TreePointSearch::Result*, MemorySpace>& intersection_results_
@@ -514,7 +487,7 @@ public:
 	template <typename Predicate, typename Value>
 	KOKKOS_FUNCTION void operator()(Predicate const &predicate, Value const & val) const;
 private:
-	Kokkos::View<Mapping2D*, MemorySpace> mappings;
+	Kokkos::View<Mapping<2>*, MemorySpace> mappings;
 	Omega_h::LOs adjacencies[2];
 	Kokkos::View<TreePointSearch::Result*, MemorySpace> intersection_results;
 };

--- a/src/pcms/localization/point_localization.h
+++ b/src/pcms/localization/point_localization.h
@@ -19,6 +19,7 @@
 #include "pcms/utility/types.h"
 #include "pcms/utility/arrays.h"
 #include "pcms/field/coordinate_system.h"
+#include "pcms/localization/point_search.h"
 
 namespace pcms
 {
@@ -89,9 +90,9 @@ public:
 	* @param elem_index the index of the desired triangle or tetrahedron in the Omega_h::Mesh
 	* @param mesh the Omega_h::Mesh with the spatial information of the triangle
 	*/
-	Mapping(int elem_index, Omega_h::Mesh const& mesh);
 
-	Mapping(Omega_h::Matrix<DIM,DIM+1> const& triangle_);
+	Mapping(Omega_h::Matrix<DIM,DIM+1> const& triangle_, 
+		Kokkos::View<Real*> const& tolerances);
 	/**
 	* @brief Default destructor
 	*/
@@ -177,6 +178,7 @@ private:
 	double opposite_edge_len_sq(int i) const;
 	
 	// REPRESENTATION
+	Kokkos::View<Real*> tolerances_;
 	// representation of the barycentric coordinate mapping, source:
 	// https://en.wikipedia.org/wiki/Barycentric_coordinate_system#Edge_approach
 	Omega_h::Matrix<DIM,DIM> bary_transform; // Column-major order
@@ -197,7 +199,8 @@ public:
 	KOKKOS_FUNCTION
 	Mapping() = default;
 
-	Mapping(Omega_h::Matrix<DIM,DIM+1> const& tetrahedron_);
+	Mapping(Omega_h::Matrix<DIM,DIM+1> const& tetrahedron_, 
+			const Kokkos::View<Real*>& tolerances);
 	/**
 	* @brief Default destructor
 	*/
@@ -232,7 +235,7 @@ public:
 	*/
 	KOKKOS_FUNCTION
 	int which(int ent_dim, 
-			  Omega_h::Vector<DIM+1> const& bary_coords) const;
+			Omega_h::Vector<DIM+1> const& bary_coords) const;
 private:	
 	/**
 	* @brief Computes the vertex offset of the point corresponding 
@@ -300,6 +303,7 @@ private:
 	KOKKOS_INLINE_FUNCTION int edge(int i) const 
 	{ return (i < 4 && i > 0) ? (OFFSETS & 3 << ((i-1)*2))>>((i-1)*2) : i; }
 	// representation
+	Kokkos::View<Real*> tolerances_;
 	Omega_h::Matrix<DIM,DIM> bary_transform; // Column-major order
 	Omega_h::Matrix<DIM,DIM+1> tetrahedron;
 	Omega_h::Vector<DIM+1> face_areas;
@@ -332,28 +336,28 @@ struct TreeWrapper
 	* @brief returns a pointer to an ArborX tree
 	*/
 	template <int dim>
-	inline std::shared_ptr<Tree_t<dim>> get_tree()
+	inline Tree_t<dim> get_tree()
 	{
 		if (dim != dim_)
 		{
 			throw pcms_error("Requested get_tree return "
 				"type does not match internal Tree_t");
 		}
-		return std::make_shared<Tree_t<dim>>(std::any_cast<Tree_t<dim>>(*tree_));
+		return std::any_cast<Tree_t<dim>>(*tree_);
 	}
 
 	/**
 	* @brief returns a pointer to a Kokkos::View of Mappings
 	*/
 	template <int dim>
-	inline std::shared_ptr<Mappings_t<dim>> get_mappings()
+	inline Mappings_t<dim> get_mappings()
 	{
 		if (dim != dim_)
 		{
 			throw pcms_error("Requested get_mappings return "
 				"type does not match internal Mappings_t");
 		}
-		return std::make_shared<Mappings_t<dim>>(std::any_cast<Mappings_t<dim>>(*mappings_));
+		return std::any_cast<Mappings_t<dim>>(*mappings_);
 	};
 private:
 	int dim_;
@@ -394,10 +398,31 @@ public:
 		Kokkos::View<Real**, MemorySpace> parametric_coords;
 	};
 
-	PointSearch() = default;
+	using PointSearchTolerances = Kokkos::View<Real*>;
+
+	explicit PointSearch(const PointSearchTolerances& tolerances)
+		: tolerances_(tolerances)
+	{
+		assert(tolerances_.is_allocated());
+	}
+
 	~PointSearch() = default;
 
 	virtual Results apply(const CoordinateView<MemorySpace>& coords) const = 0;
+	/**
+	* This function provides a temporary solution to retrieve the original
+	* behavior of the point search, which previously returned the face ID
+	* regardless of which entity the search result belonged to. Many parts of
+	* the codebase still rely on this legacy behavior. After updating the point
+	* search to return the exact entity, this function can be called to retrieve
+	* the old behavior and ensure correctness. Long term, the implementation
+	* should be updated to properly handle the new result.
+	*/
+	[[nodiscard]] virtual LO GetOwningElementId(const Results& results, int i) = 0;
+	[[nodiscard]] virtual Kokkos::View<LO*> GetOwningElementIds(
+		const Results& results) = 0;
+protected:
+	PointSearchTolerances tolerances_;
 };
 
 
@@ -409,7 +434,14 @@ public:
 	using ExecSpace = PointSearch::ExecSpace;
 	using MemorySpace = PointSearch::MemorySpace;
 	
-	TreePointSearch(const Omega_h::Mesh& mesh) : mesh_(mesh), tree(make_tree(mesh)) {}
+	TreePointSearch(Omega_h::Mesh& mesh) : 
+		PointSearch(PointSearchTolerances("tree point search tolerances", mesh.dim())), 
+		mesh_(mesh), 
+		tree(make_tree(mesh))
+	{
+		Kokkos::deep_copy(tolerances_, 1e-12);
+	}
+	TreePointSearch(Omega_h::Mesh& mesh, const PointSearchTolerances& tolerances) : PointSearch(tolerances), mesh_(mesh), tree(make_tree(mesh)) {}
 	~TreePointSearch() = default;
 	/**
 	* Given a set of points in global coordinates give the ids of the entities
@@ -419,85 +451,88 @@ public:
 	* be a negative number.
 	*/
 	Results apply(const CoordinateView<MemorySpace>& coords) const override;
+	[[nodiscard]] LO GetOwningElementId(const Results& results, int i) override;
+	[[nodiscard]] Kokkos::View<LO*> GetOwningElementIds(
+		const Results& results) override;
 private:
 	std::unique_ptr<detail::TreeWrapper> make_tree(const Omega_h::Mesh& mesh) const;
 	// Reference to the input mesh
-	Omega_h::Mesh const &mesh_;
+	Omega_h::Mesh &mesh_;
 	std::unique_ptr<detail::TreeWrapper> tree;
 };
 
 namespace detail
 {
 
-/**
-* Functor to be called when a point intersects a triangle or tetrahedron
-*/
-class CallOnIntersect3D
-{
-public:
-	using MemorySpace = TreePointSearch::MemorySpace;
-	static constexpr int DIM = 3;
-
-	CallOnIntersect3D(
-		const Kokkos::View<Mapping<3>*, MemorySpace>& mappings_,
-		const Omega_h::LOs& adjacencies0,
-		const Omega_h::LOs& adjacencies1,
-		const Omega_h::LOs& adjacencies2,
-		Kokkos::View<TreePointSearch::Dimensionality*, MemorySpace>& dimensionalities_,
-		Kokkos::View<LO*, MemorySpace>& element_ids_,
-		Kokkos::View<Real**, MemorySpace>& parametric_coords_
-	) : mappings(MakeRank1View(mappings_)),  
-		adjacencies{adjacencies0, adjacencies1, adjacencies2},
-		dimensionalities(MakeRank1View(dimensionalities_)),
-		element_ids(MakeRank1View(element_ids_)),
-		parametric_coords(MakeRank2View(parametric_coords_))
-	{
-	};
-	
 	/**
-	* Intersection callback, 
+	* Functor to be called when a point intersects a triangle or tetrahedron
 	*/
-	template <typename Predicate, typename Value>
-	KOKKOS_FUNCTION void operator()(Predicate const &predicate, Value const & val) const;
-private:
-	Rank1View<const Mapping<3>, MemorySpace> mappings;
-	Omega_h::LOs adjacencies[3];
-	Rank1View<TreePointSearch::Dimensionality, MemorySpace> dimensionalities;
-	Rank1View<LO, MemorySpace> element_ids;
-	Rank2View<Real, MemorySpace> parametric_coords;
-};
-
-
-class CallOnIntersect2D
-{
-public:
-	using MemorySpace = TreePointSearch::MemorySpace;
-	static constexpr int DIM = 2;
-
-	CallOnIntersect2D(
-		const Kokkos::View<Mapping<2>*, MemorySpace>& mappings_,
-		const Omega_h::LOs& adjacencies0,
-		const Omega_h::LOs& adjacencies1,
-		Kokkos::View<TreePointSearch::Dimensionality*, MemorySpace>& dimensionalities_,
-		Kokkos::View<LO*, MemorySpace>& element_ids_,
-		Kokkos::View<Real**, MemorySpace>& parametric_coords_
-	) : mappings(MakeRank1View(mappings_)),  
-		adjacencies{adjacencies0, adjacencies1},
-		dimensionalities(MakeRank1View(dimensionalities_)),
-		element_ids(MakeRank1View(element_ids_)),
-		parametric_coords(MakeRank2View(parametric_coords_))
+	class CallOnIntersect3D
 	{
+	public:
+		using MemorySpace = TreePointSearch::MemorySpace;
+		static constexpr int DIM = 3;
+
+		CallOnIntersect3D(
+			const Kokkos::View<Mapping<3>*, MemorySpace>& mappings_,
+			const Omega_h::LOs& adjacencies0,
+			const Omega_h::LOs& adjacencies1,
+			const Omega_h::LOs& adjacencies2,
+			Kokkos::View<TreePointSearch::Dimensionality*, MemorySpace>& dimensionalities_,
+			Kokkos::View<LO*, MemorySpace>& element_ids_,
+			Kokkos::View<Real**, MemorySpace>& parametric_coords_
+		) : mappings(MakeRank1View(mappings_)),  
+			adjacencies{adjacencies0, adjacencies1, adjacencies2},
+			dimensionalities(MakeRank1View(dimensionalities_)),
+			element_ids(MakeRank1View(element_ids_)),
+			parametric_coords(MakeRank2View(parametric_coords_))
+		{
+		};
+		
+		/**
+		* Intersection callback, 
+		*/
+		template <typename Predicate, typename Value>
+		KOKKOS_FUNCTION void operator()(Predicate const &predicate, Value const & val) const;
+	private:
+		Rank1View<const Mapping<3>, MemorySpace> mappings;
+		Omega_h::LOs adjacencies[3];
+		Rank1View<TreePointSearch::Dimensionality, MemorySpace> dimensionalities;
+		Rank1View<LO, MemorySpace> element_ids;
+		Rank2View<Real, MemorySpace> parametric_coords;
 	};
-	
-	template <typename Predicate, typename Value>
-	KOKKOS_FUNCTION void operator()(Predicate const &predicate, Value const & val) const;
-private:
-	Rank1View<const Mapping<2>, MemorySpace> mappings;
-	Omega_h::LOs adjacencies[2];
-	Rank1View<TreePointSearch::Dimensionality, MemorySpace> dimensionalities;
-	Rank1View<LO, MemorySpace> element_ids;
-	Rank2View<Real, MemorySpace> parametric_coords;
-};
+
+
+	class CallOnIntersect2D
+	{
+	public:
+		using MemorySpace = TreePointSearch::MemorySpace;
+		static constexpr int DIM = 2;
+
+		CallOnIntersect2D(
+			const Kokkos::View<Mapping<2>*, MemorySpace>& mappings_,
+			const Omega_h::LOs& adjacencies0,
+			const Omega_h::LOs& adjacencies1,
+			Kokkos::View<TreePointSearch::Dimensionality*, MemorySpace>& dimensionalities_,
+			Kokkos::View<LO*, MemorySpace>& element_ids_,
+			Kokkos::View<Real**, MemorySpace>& parametric_coords_
+		) : mappings(MakeRank1View(mappings_)),  
+			adjacencies{adjacencies0, adjacencies1},
+			dimensionalities(MakeRank1View(dimensionalities_)),
+			element_ids(MakeRank1View(element_ids_)),
+			parametric_coords(MakeRank2View(parametric_coords_))
+		{
+		};
+		
+		template <typename Predicate, typename Value>
+		KOKKOS_FUNCTION void operator()(Predicate const &predicate, Value const & val) const;
+	private:
+		Rank1View<const Mapping<2>, MemorySpace> mappings;
+		Omega_h::LOs adjacencies[2];
+		Rank1View<TreePointSearch::Dimensionality, MemorySpace> dimensionalities;
+		Rank1View<LO, MemorySpace> element_ids;
+		Rank2View<Real, MemorySpace> parametric_coords;
+	};
 
 } // namespace detail
 

--- a/src/pcms/localization/point_search.cpp
+++ b/src/pcms/localization/point_search.cpp
@@ -418,7 +418,7 @@ GridPointSearch2D::Results GridPointSearch2D::apply(
   auto tolerances = tolerances_;
   auto point_coords = points.GetValues();
   Kokkos::parallel_for(
-	  point_coords.extent(0), KOKKOS_LAMBDA(int p) {
+    point_coords.extent(0), KOKKOS_LAMBDA(int p) {
       const auto vtol = tolerances(0);
       const auto etol = tolerances(1);
 
@@ -480,7 +480,7 @@ GridPointSearch2D::Results GridPointSearch2D::apply(
           const int vb_id = edges2verts_adj.ab2b[edgeID * 2 + 1];
           const auto va = Omega_h::get_vector<2>(coords, va_id);
           const auto vb = Omega_h::get_vector<2>(coords, vb_id);
-		  
+      
           if (!normal_intersects_segment(va, vb, point))
             continue;
 
@@ -709,6 +709,13 @@ GridPointSearch3D::Results GridPointSearch3D::apply(
   auto tolerances = tolerances_;
   auto coords = coords_;
   auto point_coords = points.GetValues();
+  auto get_face = KOKKOS_LAMBDA(int i)
+  {
+    // inverse face offsets as determined by the cannonical ordering: 
+    // https://user-images.githubusercontent.com/56453280/74203616-39d27a80-4c3e-11ea-885d-b0260490e184.png
+    static const char OFFSETS = 1 << 6 | 2 << 2 | 3;
+    return (OFFSETS & 3 << (i*2))>>(i*2); 
+  };
   Kokkos::parallel_for(
     point_coords.extent(0), KOKKOS_LAMBDA(int p) {
       const auto vtol = tolerances(0);
@@ -734,16 +741,15 @@ GridPointSearch3D::Results GridPointSearch3D::apply(
         const int tetrahedronID = candidate_map.entries(i);
         const auto elem_tri2verts =
           Omega_h::gather_verts<DIM + 1>(tets2verts, tetrahedronID);
-        auto vertex_coords =
+        const auto vertex_coords =
           Omega_h::gather_vectors<DIM + 1, DIM>(coords, elem_tri2verts);
-        auto parametric_coords =
+        const Omega_h::Vector<DIM + 1> parametric_coords =
           Omega_h::barycentric_from_global<DIM, DIM>(point, vertex_coords);
 
-		    LO vertexID = -1;
+        LO vertexID = -1;
         Real best_vdist_sq = INFINITY;
         for (int k = 0; k < 4; k++) {
           Real vdist_sq = Omega_h::norm_squared(vertex_coords[k] - point);
-          // printf("%lf\n", vdist_sq);
           if (vdist_sq < vtol*vtol && vdist_sq < best_vdist_sq)
           {
             vertexID = elem_tri2verts[k];
@@ -757,8 +763,8 @@ GridPointSearch3D::Results GridPointSearch3D::apply(
           for (int j = 0; j < 4; j++)
             results.parametric_coords(p, j) = parametric_coords[j];
           found = true;
-          break;
         }
+
         if (results.dimensionalities(p) == Dimensionality::VERTEX) continue;
         
         LO edgeID = -1;
@@ -784,10 +790,56 @@ GridPointSearch3D::Results GridPointSearch3D::apply(
           for (int j = 0; j < 4; j++)
             results.parametric_coords(p, j) = parametric_coords[j];
           found = true;
-          break;
         }
 
         if (results.dimensionalities(p) == Dimensionality::EDGE) continue;
+
+        LO faceID = -1;
+        Real best_fdist_sq = INFINITY;
+        Omega_h::Matrix<DIM, DIM> tet;
+        tet[0] = vertex_coords[0] - vertex_coords[3];
+        tet[1] = vertex_coords[1] - vertex_coords[3];
+        tet[2] = vertex_coords[2] - vertex_coords[3];
+        Real tetrahedron_volume = fabs(Omega_h::determinant(tet))/6.;
+        
+        for (int k = 0; k < 4; k++)
+        {
+          LO bary_offset = get_face(k);
+          Real face_area_sq = Omega_h::norm_squared(Omega_h::cross(
+            vertex_coords[(bary_offset+1)%4] - vertex_coords[(bary_offset+3)%4], 
+            vertex_coords[(bary_offset+2)%4] - vertex_coords[(bary_offset+3)%4]))/4.;
+          
+          Real fdist_sq = parametric_coords[bary_offset]*3*tetrahedron_volume;
+          fdist_sq *= fdist_sq;
+          fdist_sq /= face_area_sq;
+
+          bool inside = true;
+          for (int j = 0; j < 4; j++)
+          {
+            if (j == bary_offset) continue;
+            if (parametric_coords[j] < 0)
+            {
+              inside = false;
+              break;
+            }
+          }
+
+          if (fdist_sq < ftol*ftol && fdist_sq < best_fdist_sq && inside)
+          {
+            faceID = tets2faces_adj.ab2b[tetrahedronID * 4 + k];
+            best_fdist_sq = fdist_sq;
+          }
+        }
+        if (faceID > -1)
+        {
+          results.dimensionalities(p) = Dimensionality::FACE;
+          results.element_ids(p) = faceID;
+          for (int j = 0; j < 4; j++)
+            results.parametric_coords(p, j) = parametric_coords[j];
+          found = true;
+        }
+
+        if (results.dimensionalities(p) == Dimensionality::FACE) continue;
 
         if (Omega_h::is_barycentric_inside(parametric_coords)) {
           results.dimensionalities(p) = Dimensionality::REGION;
@@ -795,7 +847,6 @@ GridPointSearch3D::Results GridPointSearch3D::apply(
           for (int j = 0; j < 4; j++)
             results.parametric_coords(p, j) = parametric_coords[j];
           found = true;
-          break;
         }
 
         // TODO: Get nearest element if no tetrahedron found

--- a/src/pcms/localization/point_search.cpp
+++ b/src/pcms/localization/point_search.cpp
@@ -694,18 +694,26 @@ GridPointSearch3D::Results GridPointSearch3D::apply(
     Kokkos::View<Real**>("parametric coordinates", points.GetValues().extent(0), 
                          points.GetValues().extent(1) + 1)
   };
+  Kokkos::deep_copy(results.dimensionalities, Dimensionality::NO_INTERSECT);
+  Kokkos::deep_copy(results.element_ids, -1);
+  Kokkos::deep_copy(results.parametric_coords, 0.);
   auto num_rows = candidate_map_.numRows();
   // needed so that we don't capture this ptr which will be memory error on cuda
   auto grid = grid_;
   auto candidate_map = candidate_map_;
-  auto tris2verts = tris2verts_;
-  auto tris2verts_adj = tris2verts_adj_;
-  auto tris2edges_adj = tris2edges_adj_;
+  auto tets2verts = tets2verts_;
+  auto tets2verts_adj = tets2verts_adj_;
+  auto tets2edges_adj = tets2edges_adj_;
+  auto tets2faces_adj = tets2faces_adj_;
   auto edges2verts_adj = edges2verts_adj_;
+  auto tolerances = tolerances_;
   auto coords = coords_;
   auto point_coords = points.GetValues();
   Kokkos::parallel_for(
     point_coords.extent(0), KOKKOS_LAMBDA(int p) {
+      const auto vtol = tolerances(0);
+      const auto etol = tolerances(1);
+      const auto ftol = tolerances(2);
       Omega_h::Vector<DIM> point;
       for (int i = 0; i < DIM; ++i) {
         point[i] = point_coords(p, i);
@@ -717,23 +725,73 @@ GridPointSearch3D::Results GridPointSearch3D::apply(
       auto candidates_end = candidate_map.row_map(cell_id + 1);
       bool found = false;
 
-      auto nearest_triangle = candidates_begin;
-      auto dimensionality = GridPointSearch3D::Results::Dimensionality::EDGE;
+      auto nearest_tetrahedron = candidates_begin;
+      auto dimensionality = Dimensionality::EDGE;
       Omega_h::Vector<DIM + 1> parametric_coords_to_nearest;
       // create array that's size of number of candidates x num coords to store
       // parametric inversion
       for (auto i = candidates_begin; i < candidates_end; ++i) {
-        const int triangleID = candidate_map.entries(i);
+        const int tetrahedronID = candidate_map.entries(i);
         const auto elem_tri2verts =
-          Omega_h::gather_verts<DIM + 1>(tris2verts, triangleID);
+          Omega_h::gather_verts<DIM + 1>(tets2verts, tetrahedronID);
         auto vertex_coords =
           Omega_h::gather_vectors<DIM + 1, DIM>(coords, elem_tri2verts);
         auto parametric_coords =
           Omega_h::barycentric_from_global<DIM, DIM>(point, vertex_coords);
 
+		    LO vertexID = -1;
+        Real best_vdist_sq = INFINITY;
+        for (int k = 0; k < 4; k++) {
+          Real vdist_sq = Omega_h::norm_squared(vertex_coords[k] - point);
+          // printf("%lf\n", vdist_sq);
+          if (vdist_sq < vtol*vtol && vdist_sq < best_vdist_sq)
+          {
+            vertexID = elem_tri2verts[k];
+            best_vdist_sq = vdist_sq;
+          }
+        }
+        if (vertexID > -1)
+        {
+          results.dimensionalities(p) = Dimensionality::VERTEX;
+          results.element_ids(p) = vertexID;
+          for (int j = 0; j < 4; j++)
+            results.parametric_coords(p, j) = parametric_coords[j];
+          found = true;
+          break;
+        }
+        if (results.dimensionalities(p) == Dimensionality::VERTEX) continue;
+        
+        LO edgeID = -1;
+        Real best_edist = INFINITY;
+        for (int j = 0; j < 6; ++j) {
+          const int curr_edgeID = tets2edges_adj.ab2b[tetrahedronID * 6 + j];
+          const int va_id = edges2verts_adj.ab2b[curr_edgeID * 2 + 0];
+          const int vb_id = edges2verts_adj.ab2b[curr_edgeID * 2 + 1];
+          const auto va = Omega_h::get_vector<3>(coords, va_id);
+          const auto vb = Omega_h::get_vector<3>(coords, vb_id);
+          if (!normal_intersects_segment(va, vb, point))
+            continue;
+          const auto de = distance_from_line(va, vb, point);
+          if (de < etol && de < best_edist) {
+            best_edist = de;
+            edgeID = curr_edgeID;
+          }
+        }
+        if (edgeID > -1)
+        {
+          results.dimensionalities(p) = Dimensionality::EDGE;
+          results.element_ids(p) = edgeID;
+          for (int j = 0; j < 4; j++)
+            results.parametric_coords(p, j) = parametric_coords[j];
+          found = true;
+          break;
+        }
+
+        if (results.dimensionalities(p) == Dimensionality::EDGE) continue;
+
         if (Omega_h::is_barycentric_inside(parametric_coords)) {
-          results.dimensionalities(p) = GridPointSearch3D::Results::Dimensionality::REGION;
-          results.element_ids(p) = triangleID;
+          results.dimensionalities(p) = Dimensionality::REGION;
+          results.element_ids(p) = tetrahedronID;
           for (int j = 0; j < 4; j++)
             results.parametric_coords(p, j) = parametric_coords[j];
           found = true;
@@ -743,7 +801,7 @@ GridPointSearch3D::Results GridPointSearch3D::apply(
         // TODO: Get nearest element if no tetrahedron found
       }
       if (!found) {
-        LO nearest_elem = candidate_map.entries(nearest_triangle);
+        LO nearest_elem = candidate_map.entries(nearest_tetrahedron);
         results.dimensionalities(p) = dimensionality;
         results.element_ids(p) = -nearest_elem;
         for (int j = 0; j < 4; j++)
@@ -784,9 +842,10 @@ GridPointSearch3D::GridPointSearch3D(Omega_h::Mesh& mesh, LO Nx, LO Ny, LO Nz,
   candidate_map_ =
     detail::construct_intersection_map_3d(mesh, grid_, grid_h(0).GetNumCells());
   coords_ = mesh.coords();
-  tris2verts_ = mesh.ask_elem_verts();
-  tris2edges_adj_ = mesh.ask_down(Omega_h::FACE, Omega_h::EDGE);
-  tris2verts_adj_ = mesh.ask_down(Omega_h::FACE, Omega_h::VERT);
+  tets2verts_ = mesh.ask_elem_verts();
+  tets2faces_adj_ = mesh.ask_down(Omega_h::REGION, Omega_h::FACE);
+  tets2edges_adj_ = mesh.ask_down(Omega_h::REGION, Omega_h::EDGE);
+  tets2verts_adj_ = mesh.ask_down(Omega_h::REGION, Omega_h::VERT);
   edges2verts_adj_ = mesh.ask_down(Omega_h::EDGE, Omega_h::VERT);
   verts2regions_up_ = mesh.ask_up(Omega_h::VERT, Omega_h::REGION);
   edges2regions_up_ = mesh.ask_up(Omega_h::EDGE, Omega_h::REGION);

--- a/src/pcms/localization/point_search.cpp
+++ b/src/pcms/localization/point_search.cpp
@@ -396,11 +396,16 @@ OMEGA_H_INLINE double myreduce(const Omega_h::Vector<n>& x,
   return out;
 }
 
-Kokkos::View<GridPointSearch2D::Result*> GridPointSearch2D::operator()(
-  Kokkos::View<const Real* [DIM]> points) const
+GridPointSearch2D::Results GridPointSearch2D::apply(
+  const CoordinateView<PointSearch::MemorySpace>& points) const
 {
-  Kokkos::View<GridPointSearch2D::Result*> results("point search result",
-                                                   points.extent(0));
+  Results results{
+    Kokkos::View<Dimensionality*>("dimensionalities", points.GetValues().extent(0)),
+    Kokkos::View<LO*>("element IDs", points.GetValues().extent(0)),
+    Kokkos::View<Real**>("parametric coordinates", points.GetValues().extent(0), 
+                         points.GetValues().extent(1) + 1)
+  };
+
   auto num_rows = candidate_map_.numRows();
   // needed so that we don't capture this ptr which will be memory error on cuda
   auto grid = grid_;
@@ -411,10 +416,14 @@ Kokkos::View<GridPointSearch2D::Result*> GridPointSearch2D::operator()(
   auto edges2verts_adj = edges2verts_adj_;
   auto coords = coords_;
   auto tolerances = tolerances_;
+  auto point_coords = points.GetValues();
   Kokkos::parallel_for(
-    points.extent(0), KOKKOS_LAMBDA(int p) {
+	  point_coords.extent(0), KOKKOS_LAMBDA(int p) {
+      const auto vtol = tolerances(0);
+      const auto etol = tolerances(1);
+
       Omega_h::Vector<2> point(
-        std::initializer_list<double>{points(p, 0), points(p, 1)});
+        std::initializer_list<double>{point_coords(p, 0), point_coords(p, 1)});
       auto cell_id = grid(0).ClosestCellID(point);
       assert(cell_id < num_rows && cell_id >= 0);
       auto candidates_begin = candidate_map.row_map(cell_id);
@@ -471,14 +480,14 @@ Kokkos::View<GridPointSearch2D::Result*> GridPointSearch2D::operator()(
           const int vb_id = edges2verts_adj.ab2b[edgeID * 2 + 1];
           const auto va = Omega_h::get_vector<2>(coords, va_id);
           const auto vb = Omega_h::get_vector<2>(coords, vb_id);
-
+		  
           if (!normal_intersects_segment(va, vb, point))
             continue;
 
           const auto de = distance_from_line(va, vb, point);
           if ((de < best_edge_dist) ||
-              ((de == best_edge_dist) && (edgeID < best_edge_id)) ||
-              ((de == best_edge_dist) && (edgeID == best_edge_id) &&
+              ((fabs(de - best_edge_dist) < etol) && (edgeID < best_edge_id)) ||
+              ((fabs(de - best_edge_dist) < etol) && (edgeID == best_edge_id) &&
                (triangleID < best_edge_tid_min))) {
             best_edge_dist = de;
             best_edge_id = edgeID;
@@ -486,7 +495,7 @@ Kokkos::View<GridPointSearch2D::Result*> GridPointSearch2D::operator()(
             best_edge_tid_max = triangleID;
             best_edge_bary_min = parametric_coords;
             best_edge_bary_max = parametric_coords;
-          } else if ((de == best_edge_dist) && (edgeID == best_edge_id)) {
+          } else if ((fabs(de - best_edge_dist) < etol) && (edgeID == best_edge_id)) {
             // Track the extents of face IDs sharing this nearest edge
             if (triangleID < best_edge_tid_min) {
               best_edge_tid_min = triangleID;
@@ -508,10 +517,6 @@ Kokkos::View<GridPointSearch2D::Result*> GridPointSearch2D::operator()(
           }
         }
       }
-
-      const auto vtol = tolerances(0);
-      const auto etol = tolerances(1);
-
       // If we found an inside face, compute its edge distance using
       // barycentric-only helper to check for edge classification while
       // preserving the containing face ID.
@@ -545,8 +550,9 @@ Kokkos::View<GridPointSearch2D::Result*> GridPointSearch2D::operator()(
         }
       }
 
-      GridPointSearch2D::Result::Dimensionality dim_out =
-        GridPointSearch2D::Result::Dimensionality::REGION;
+      // found_inside && inside_edge_dist <= etol)
+      GridPointSearch2D::Results::Dimensionality dim_out =
+        GridPointSearch2D::Results::Dimensionality::NO_INTERSECT;
       LO element_id_out = -1;
       Omega_h::Vector<3> bary_out{0.0, 0.0, 0.0};
 
@@ -555,13 +561,13 @@ Kokkos::View<GridPointSearch2D::Result*> GridPointSearch2D::operator()(
       // Only points with no candidates at all get negative IDs
       if (best_vertex_id >= 0 && best_vertex_dist <= vtol) {
         // Point within vertex tolerance - still inside the mesh
-        dim_out = GridPointSearch2D::Result::Dimensionality::VERTEX;
+        dim_out = GridPointSearch2D::Results::Dimensionality::VERTEX;
         element_id_out = best_vertex_id;
         bary_out = best_vertex_bary;
       } else if ((best_edge_id >= 0 && best_edge_dist <= etol) ||
                  (found_inside && inside_edge_dist <= etol)) {
         // Point within edge tolerance - still inside the mesh
-        dim_out = GridPointSearch2D::Result::Dimensionality::EDGE;
+        dim_out = GridPointSearch2D::Results::Dimensionality::EDGE;
         if (found_inside && inside_edge_dist <= etol &&
             inside_edge_argmin >= 0) {
           element_id_out = inside_edge_id;
@@ -572,7 +578,7 @@ Kokkos::View<GridPointSearch2D::Result*> GridPointSearch2D::operator()(
         }
       } else if (found_inside) {
         // Point inside face
-        dim_out = GridPointSearch2D::Result::Dimensionality::FACE;
+        dim_out = GridPointSearch2D::Results::Dimensionality::FACE;
         element_id_out = inside_face_id;
         bary_out = inside_face_bary;
       } else {
@@ -580,12 +586,12 @@ Kokkos::View<GridPointSearch2D::Result*> GridPointSearch2D::operator()(
         // Only negate if we truly have no candidates at all.
         if (best_vertex_id >= 0 &&
             (best_vertex_dist <= best_edge_dist || best_edge_id < 0)) {
-          dim_out = GridPointSearch2D::Result::Dimensionality::VERTEX;
+          dim_out = GridPointSearch2D::Results::Dimensionality::VERTEX;
           element_id_out = best_vertex_id;
           bary_out = best_vertex_bary;
           element_id_out = -element_id_out;
         } else if (best_edge_id >= 0) {
-          dim_out = GridPointSearch2D::Result::Dimensionality::EDGE;
+          dim_out = GridPointSearch2D::Results::Dimensionality::EDGE;
           element_id_out = best_edge_id;
           bary_out = best_edge_bary_min;
           element_id_out = -element_id_out;
@@ -594,7 +600,10 @@ Kokkos::View<GridPointSearch2D::Result*> GridPointSearch2D::operator()(
         }
       }
 
-      results(p) = GridPointSearch2D::Result{dim_out, element_id_out, bary_out};
+      results.dimensionalities(p) = dim_out;
+      results.element_ids(p) = element_id_out;
+      for (int j = 0; j < 3; j++)
+        results.parametric_coords(p, j) = bary_out(j);
     });
 
   return results;
@@ -602,14 +611,14 @@ Kokkos::View<GridPointSearch2D::Result*> GridPointSearch2D::operator()(
 
 GridPointSearch2D::GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny)
   : GridPointSearch2D(mesh, Nx, Ny,
-                      PointSearchTolerances{"point search 2d tolerances"})
+                      PointSearchTolerances("point search 2d tolerances", mesh.dim()))
 {
   Kokkos::deep_copy(tolerances_, 1E-12);
 }
 
 GridPointSearch2D::GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny,
                                      const PointSearchTolerances& tolerances)
-  : PointLocalizationSearch(tolerances), mesh_(mesh)
+  : PointSearch(tolerances), mesh_(mesh)
 {
   auto mesh_bbox = Omega_h::get_bounding_box<2>(&mesh);
   auto grid_h = Kokkos::create_mirror_view(grid_);
@@ -633,42 +642,42 @@ GridPointSearch2D::GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny,
   verts2faces_up_ = mesh.ask_up(Omega_h::VERT, Omega_h::FACE);
 }
 
-LO GridPointSearch2D::GetOwningElementId(const Result& result)
+LO GridPointSearch2D::GetOwningElementId(const Results& results, int i)
 {
   const LO query_id =
-    (result.element_id < 0) ? -result.element_id : result.element_id;
+    (results.element_ids(i) < 0) ? -results.element_ids(i) : results.element_ids(i);
   return pcms::GetOwningElementId(
-    mesh_, 2, static_cast<int>(result.dimensionality), query_id);
+    mesh_, 2, static_cast<int>(results.dimensionalities(i)), query_id);
 }
 
 Kokkos::View<LO*> GridPointSearch2D::GetOwningElementIds(
-  Kokkos::View<const Result*> results)
+  Results const& results)
 {
-  Kokkos::View<LO*> owners("point search owning face ids", results.extent(0));
+  Kokkos::View<LO*> owners("point search owning face ids", 
+                           results.dimensionalities.extent(0));
   auto edges2faces_up = edges2faces_up_;
   auto verts2faces_up = verts2faces_up_;
   constexpr int mesh_dim = 2;
   Kokkos::parallel_for(
-    results.extent(0), KOKKOS_LAMBDA(const LO i) {
-      const auto result = results(i);
-      LO element_id = result.element_id;
+    results.dimensionalities.extent(0), KOKKOS_LAMBDA(const LO i) {
+      LO element_id = results.element_ids(i);
       if (element_id < 0)
         element_id = -element_id;
 
       LO owner = -1;
       if (element_id >= 0) {
-        if (result.dimensionality == Result::Dimensionality::FACE) {
+        if (results.dimensionalities(i) == Results::Dimensionality::FACE) {
           owner = GetOwningElementIdFromAdj(
-            edges2faces_up, Result::Dimensionality::FACE,
-            Result::Dimensionality::FACE, element_id);
-        } else if (result.dimensionality == Result::Dimensionality::EDGE) {
+            edges2faces_up, Results::Dimensionality::FACE,
+            Results::Dimensionality::FACE, element_id);
+        } else if (results.dimensionalities(i) == Results::Dimensionality::EDGE) {
           owner = GetOwningElementIdFromAdj(
-            edges2faces_up, Result::Dimensionality::EDGE,
-            Result::Dimensionality::FACE, element_id);
-        } else if (result.dimensionality == Result::Dimensionality::VERTEX) {
+            edges2faces_up, Results::Dimensionality::EDGE,
+            Results::Dimensionality::FACE, element_id);
+        } else if (results.dimensionalities(i) == Results::Dimensionality::VERTEX) {
           owner = GetOwningElementIdFromAdj(
-            verts2faces_up, Result::Dimensionality::VERTEX,
-            Result::Dimensionality::FACE, element_id);
+            verts2faces_up, Results::Dimensionality::VERTEX,
+            Results::Dimensionality::FACE, element_id);
         }
       }
       owners(i) = owner;
@@ -676,11 +685,15 @@ Kokkos::View<LO*> GridPointSearch2D::GetOwningElementIds(
   return owners;
 }
 
-Kokkos::View<GridPointSearch3D::Result*> GridPointSearch3D::operator()(
-  Kokkos::View<const Real* [DIM]> points) const
+GridPointSearch3D::Results GridPointSearch3D::apply(
+  const CoordinateView<PointSearch::MemorySpace>& points) const
 {
-  Kokkos::View<GridPointSearch3D::Result*> results("point search result",
-                                                   points.extent(0));
+  Results results{
+    Kokkos::View<Dimensionality*>("dimensionalities", points.GetValues().extent(0)),
+    Kokkos::View<LO*>("element IDs", points.GetValues().extent(0)),
+    Kokkos::View<Real**>("parametric coordinates", points.GetValues().extent(0), 
+                         points.GetValues().extent(1) + 1)
+  };
   auto num_rows = candidate_map_.numRows();
   // needed so that we don't capture this ptr which will be memory error on cuda
   auto grid = grid_;
@@ -690,11 +703,12 @@ Kokkos::View<GridPointSearch3D::Result*> GridPointSearch3D::operator()(
   auto tris2edges_adj = tris2edges_adj_;
   auto edges2verts_adj = edges2verts_adj_;
   auto coords = coords_;
+  auto point_coords = points.GetValues();
   Kokkos::parallel_for(
-    points.extent(0), KOKKOS_LAMBDA(int p) {
+    point_coords.extent(0), KOKKOS_LAMBDA(int p) {
       Omega_h::Vector<DIM> point;
       for (int i = 0; i < DIM; ++i) {
-        point[i] = points(p, i);
+        point[i] = point_coords(p, i);
       }
 
       auto cell_id = grid(0).ClosestCellID(point);
@@ -704,7 +718,7 @@ Kokkos::View<GridPointSearch3D::Result*> GridPointSearch3D::operator()(
       bool found = false;
 
       auto nearest_triangle = candidates_begin;
-      auto dimensionality = GridPointSearch3D::Result::Dimensionality::EDGE;
+      auto dimensionality = GridPointSearch3D::Results::Dimensionality::EDGE;
       Omega_h::Vector<DIM + 1> parametric_coords_to_nearest;
       // create array that's size of number of candidates x num coords to store
       // parametric inversion
@@ -718,9 +732,10 @@ Kokkos::View<GridPointSearch3D::Result*> GridPointSearch3D::operator()(
           Omega_h::barycentric_from_global<DIM, DIM>(point, vertex_coords);
 
         if (Omega_h::is_barycentric_inside(parametric_coords)) {
-          results(p) = GridPointSearch3D::Result{
-            GridPointSearch3D::Result::Dimensionality::REGION, triangleID,
-            parametric_coords};
+          results.dimensionalities(p) = GridPointSearch3D::Results::Dimensionality::REGION;
+          results.element_ids(p) = triangleID;
+          for (int j = 0; j < 4; j++)
+            results.parametric_coords(p, j) = parametric_coords[j];
           found = true;
           break;
         }
@@ -729,8 +744,10 @@ Kokkos::View<GridPointSearch3D::Result*> GridPointSearch3D::operator()(
       }
       if (!found) {
         LO nearest_elem = candidate_map.entries(nearest_triangle);
-        results(p) = GridPointSearch3D::Result{dimensionality, -nearest_elem,
-                                               parametric_coords_to_nearest};
+        results.dimensionalities(p) = dimensionality;
+        results.element_ids(p) = -nearest_elem;
+        for (int j = 0; j < 4; j++)
+          results.parametric_coords(p,j) = parametric_coords_to_nearest[j];
       }
     });
 
@@ -739,14 +756,14 @@ Kokkos::View<GridPointSearch3D::Result*> GridPointSearch3D::operator()(
 
 GridPointSearch3D::GridPointSearch3D(Omega_h::Mesh& mesh, LO Nx, LO Ny, LO Nz)
   : GridPointSearch3D(mesh, Nx, Ny, Nz,
-                      PointSearchTolerances{"point search 3d tolerances"})
+                      PointSearchTolerances("point search 3d tolerances", 3))
 {
-  Kokkos::deep_copy(tolerances_, 0);
+  Kokkos::deep_copy(tolerances_, 1e-12);
 }
 
 GridPointSearch3D::GridPointSearch3D(Omega_h::Mesh& mesh, LO Nx, LO Ny, LO Nz,
                                      const PointSearchTolerances& tolerances)
-  : PointLocalizationSearch(tolerances), mesh_(mesh)
+  : PointSearch(tolerances), mesh_(mesh)
 {
   auto mesh_bbox = Omega_h::get_bounding_box<3>(&mesh);
   auto grid_h = Kokkos::create_mirror_view(grid_);
@@ -776,47 +793,47 @@ GridPointSearch3D::GridPointSearch3D(Omega_h::Mesh& mesh, LO Nx, LO Ny, LO Nz,
   faces2regions_up_ = mesh.ask_up(Omega_h::FACE, Omega_h::REGION);
 }
 
-LO GridPointSearch3D::GetOwningElementId(const Result& result)
+LO GridPointSearch3D::GetOwningElementId(const Results& results, int i)
 {
   const LO query_id =
-    (result.element_id < 0) ? -result.element_id : result.element_id;
+    (results.element_ids(i) < 0) ? -results.element_ids(i) : results.element_ids(i);
   return pcms::GetOwningElementId(
-    mesh_, 3, static_cast<int>(result.dimensionality), query_id);
+    mesh_, 3, static_cast<int>(results.dimensionalities(i)), query_id);
 }
 
 Kokkos::View<LO*> GridPointSearch3D::GetOwningElementIds(
-  Kokkos::View<const Result*> results)
+  const Results& results)
 {
-  Kokkos::View<LO*> owners("point search owning region ids", results.extent(0));
+  Kokkos::View<LO*> owners("point search owning region ids", 
+                           results.dimensionalities.extent(0));
   auto verts2regions_up = verts2regions_up_;
   auto edges2regions_up = edges2regions_up_;
   auto faces2regions_up = faces2regions_up_;
   constexpr int mesh_dim = 3;
   Kokkos::parallel_for(
-    results.extent(0), KOKKOS_LAMBDA(const LO i) {
-      const auto result = results(i);
-      LO element_id = result.element_id;
+    owners.extent(0), KOKKOS_LAMBDA(const LO i) {
+      LO element_id = results.element_ids(i);
       if (element_id < 0)
         element_id = -element_id;
 
       LO owner = -1;
       if (element_id >= 0) {
-        if (result.dimensionality == Result::Dimensionality::REGION) {
+        if (results.dimensionalities(i) == Results::Dimensionality::REGION) {
           owner = GetOwningElementIdFromAdj(
-            faces2regions_up, Result::Dimensionality::REGION,
-            Result::Dimensionality::REGION, element_id);
-        } else if (result.dimensionality == Result::Dimensionality::FACE) {
+            faces2regions_up, Results::Dimensionality::REGION,
+            Results::Dimensionality::REGION, element_id);
+        } else if (results.dimensionalities(i) == Results::Dimensionality::FACE) {
           owner = GetOwningElementIdFromAdj(
-            faces2regions_up, Result::Dimensionality::FACE,
-            Result::Dimensionality::REGION, element_id);
-        } else if (result.dimensionality == Result::Dimensionality::EDGE) {
+            faces2regions_up, Results::Dimensionality::FACE,
+            Results::Dimensionality::REGION, element_id);
+        } else if (results.dimensionalities(i) == Results::Dimensionality::EDGE) {
           owner = GetOwningElementIdFromAdj(
-            edges2regions_up, Result::Dimensionality::EDGE,
-            Result::Dimensionality::REGION, element_id);
-        } else if (result.dimensionality == Result::Dimensionality::VERTEX) {
+            edges2regions_up, Results::Dimensionality::EDGE,
+            Results::Dimensionality::REGION, element_id);
+        } else if (results.dimensionalities(i) == Results::Dimensionality::VERTEX) {
           owner = GetOwningElementIdFromAdj(
-            verts2regions_up, Result::Dimensionality::VERTEX,
-            Result::Dimensionality::REGION, element_id);
+            verts2regions_up, Results::Dimensionality::VERTEX,
+            Results::Dimensionality::REGION, element_id);
         }
       }
       owners(i) = owner;

--- a/src/pcms/localization/point_search.cpp
+++ b/src/pcms/localization/point_search.cpp
@@ -644,10 +644,18 @@ GridPointSearch2D::GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny,
 
 LO GridPointSearch2D::GetOwningElementId(const Results& results, int i)
 {
-  const LO query_id =
-    (results.element_ids(i) < 0) ? -results.element_ids(i) : results.element_ids(i);
+  const Kokkos::View<LO[1]> query_id{""};
+  const Kokkos::View<Dimensionality[1]> dim{""};
+  Kokkos::parallel_for(1, KOKKOS_LAMBDA(const int){
+    query_id(0) = (results.element_ids(i) < 0) ? -results.element_ids(i) : results.element_ids(i);
+    dim(0) = results.dimensionalities(i);
+  });
+  auto query_id_h = Kokkos::create_mirror_view(query_id);  
+  auto dim_h = Kokkos::create_mirror_view(dim);
+  Kokkos::deep_copy(query_id_h, query_id);
+  Kokkos::deep_copy(dim_h, dim);
   return pcms::GetOwningElementId(
-    mesh_, 2, static_cast<int>(results.dimensionalities(i)), query_id);
+    mesh_, 2, static_cast<int>(dim_h(0)), query_id_h(0));
 }
 
 Kokkos::View<LO*> GridPointSearch2D::GetOwningElementIds(

--- a/src/pcms/localization/point_search.h
+++ b/src/pcms/localization/point_search.h
@@ -10,6 +10,7 @@
 #include "pcms/utility/types.h"
 #include "pcms/utility/uniform_grid.h"
 #include "pcms/utility/bounding_box.h"
+#include "pcms/field/coordinate_system.h"
 
 namespace pcms
 {
@@ -22,33 +23,33 @@ namespace pcms
  * top-level dimension).
  */
 LO GetOwningElementId(Omega_h::Mesh& mesh, int mesh_dim, int entity_dim,
-                      LO element_id);
+											LO element_id);
 
 template <typename DimEnum>
 KOKKOS_INLINE_FUNCTION LO
 GetOwningElementIdFromAdj(const Omega_h::Adj& upward_adj, DimEnum entity_dim,
-                          DimEnum target_dim, LO element_id)
+													DimEnum target_dim, LO element_id)
 {
-  if (element_id < 0)
-    return -1;
+	if (element_id < 0)
+		return -1;
 
-  // If entity is already at target dimension, return it directly
-  if (static_cast<int>(entity_dim) == static_cast<int>(target_dim))
-    return element_id;
+	// If entity is already at target dimension, return it directly
+	if (static_cast<int>(entity_dim) == static_cast<int>(target_dim))
+		return element_id;
 
-  const auto begin = upward_adj.a2ab[element_id];
-  const auto end = upward_adj.a2ab[element_id + 1];
-  if (begin >= end)
-    return -1;
+	const auto begin = upward_adj.a2ab[element_id];
+	const auto end = upward_adj.a2ab[element_id + 1];
+	if (begin >= end)
+		return -1;
 
-  // Find the smallest owning element ID
-  LO owner = upward_adj.ab2b[begin];
-  for (auto i = begin + 1; i < end; ++i) {
-    const LO candidate = upward_adj.ab2b[i];
-    if (candidate < owner)
-      owner = candidate;
-  }
-  return owner;
+	// Find the smallest owning element ID
+	LO owner = upward_adj.ab2b[begin];
+	for (auto i = begin + 1; i < end; ++i) {
+		const LO candidate = upward_adj.ab2b[i];
+		if (candidate < owner)
+			owner = candidate;
+	}
+	return owner;
 }
 
 //
@@ -59,142 +60,152 @@ namespace detail
 {
 Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>
 construct_intersection_map_2d(Omega_h::Mesh& mesh,
-                              Kokkos::View<Uniform2DGrid[1]> grid,
-                              int num_grid_cells);
+															Kokkos::View<Uniform2DGrid[1]> grid,
+															int num_grid_cells);
 }
 
 [[nodiscard]] KOKKOS_FUNCTION bool triangle_intersects_bbox(
-  const Omega_h::Matrix<2, 3>& coords, const AABBox<2>& bbox);
+	const Omega_h::Matrix<2, 3>& coords, const AABBox<2>& bbox);
 
-template <int dim>
-class PointLocalizationSearch
+/**
+ * Point search base class
+ */
+class PointSearch
 {
 public:
-  struct Result
-  {
-    enum class Dimensionality
-    {
-      VERTEX = 0,
-      EDGE = 1,
-      FACE = 2,
-      REGION = 3
-    };
+	using ExecSpace = Omega_h::ExecSpace;
+	using MemorySpace = ExecSpace::memory_space;
+	/**
+	* Results type gives dimensionalities of point intersection, the intersected
+	* element IDs, and the barycentric coordinate mappings of each point as follows:
+	* the `i`th input point has intersection dimensionality of 
+	* `dimensionalities(i)`, intersected element ID of `element_ids(i)`, and 
+	* likewise parametric coordinate mapping of `parametric_coords(i,0..d)`
+	* where `d` is the dimension of the space
+	*/
+	struct Results
+	{
+		enum class Dimensionality
+		{
+			VERTEX = 0,
+			EDGE = 1,
+			FACE = 2,
+			REGION = 3,
+			NO_INTERSECT = 4
+		};
 
-    Dimensionality dimensionality;
-    LO element_id; // ID of the actual entity (vertex/edge/face/region)
-    Omega_h::Vector<dim + 1> parametric_coords;
-  };
+		Kokkos::View<Dimensionality*, MemorySpace> dimensionalities;
+		Kokkos::View<LO*, MemorySpace> element_ids;
+		Kokkos::View<Real**, MemorySpace> parametric_coords;
+	};
 
-  static constexpr auto DIM = dim;
+	using PointSearchTolerances = Kokkos::View<Real*>;
 
-  using PointSearchTolerances = Kokkos::View<Real[DIM]>;
+	explicit PointSearch(const PointSearchTolerances& tolerances)
+		: tolerances_(tolerances)
+	{
+		assert(tolerances_.is_allocated());
+	}
 
-  explicit PointLocalizationSearch(const PointSearchTolerances& tolerances)
-    : tolerances_(tolerances)
-  {
-    assert(tolerances_.is_allocated());
-  }
+	~PointSearch() = default;
 
-  virtual Kokkos::View<Result*> operator()(
-    Kokkos::View<const Real* [dim]> point) const = 0;
-
-  /**
-   * This function provides a temporary solution to retrieve the original
-   * behavior of the point search, which previously returned the face ID
-   * regardless of which entity the search result belonged to. Many parts of
-   * the codebase still rely on this legacy behavior. After updating the point
-   * search to return the exact entity, this function can be called to retrieve
-   * the old behavior and ensure correctness. Long term, the implementation
-   * should be updated to properly handle the new result.
-   */
-  [[nodiscard]] virtual LO GetOwningElementId(const Result& result) = 0;
-  [[nodiscard]] virtual Kokkos::View<LO*> GetOwningElementIds(
-    Kokkos::View<const Result*> results) = 0;
-  virtual ~PointLocalizationSearch() = default;
-
+	virtual Results apply(const CoordinateView<MemorySpace>& coords) const = 0;
+	/**
+	* This function provides a temporary solution to retrieve the original
+	* behavior of the point search, which previously returned the face ID
+	* regardless of which entity the search result belonged to. Many parts of
+	* the codebase still rely on this legacy behavior. After updating the point
+	* search to return the exact entity, this function can be called to retrieve
+	* the old behavior and ensure correctness. Long term, the implementation
+	* should be updated to properly handle the new result.
+	*/
+	[[nodiscard]] virtual LO GetOwningElementId(const Results& results, int i) = 0;
+	[[nodiscard]] virtual Kokkos::View<LO*> GetOwningElementIds(
+		const Results& results) = 0;
 protected:
-  PointSearchTolerances tolerances_;
+	PointSearchTolerances tolerances_;
 };
 
-using PointLocalizationSearch2D = PointLocalizationSearch<2>;
-using PointLocalizationSearch3D = PointLocalizationSearch<3>;
-
-class GridPointSearch2D : public PointLocalizationSearch2D
+class GridPointSearch2D : public PointSearch
 {
-  using CandidateMapT =
-    Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>;
+	using CandidateMapT =
+		Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>;
 
 public:
-  using Result = PointLocalizationSearch2D::Result;
+	static constexpr int DIM = 2;
+	
+	using Results = PointSearch::Results;
+	using Dimensionality = Results::Dimensionality;
 
-  GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny);
-  GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny,
-                    const PointSearchTolerances& tolerances);
+	GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny);
+	GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny,
+										const PointSearchTolerances& tolerances);
 
-  /**
-   *  given a point in global coordinates give the id of the triangle that the
-   * point lies within and the parametric coordinate of the point within the
-   * triangle. If the point does not lie within any triangle element. Then the
-   * id will be a negative number and (TODO) will return a negative id of the
-   * closest element
-   */
-  Kokkos::View<Result*> operator()(
-    Kokkos::View<const Real* [DIM]> point) const override;
-  [[nodiscard]] LO GetOwningElementId(const Result& result) override;
-  [[nodiscard]] Kokkos::View<LO*> GetOwningElementIds(
-    Kokkos::View<const Result*> results) override;
+	/**
+	 *  given a point in global coordinates give the id of the triangle that the
+	 * point lies within and the parametric coordinate of the point within the
+	 * triangle. If the point does not lie within any triangle element. Then the
+	 * id will be a negative number and (TODO) will return a negative id of the
+	 * closest element
+	 */
+	Results apply(
+		const CoordinateView<MemorySpace>& coords) const override;
+	[[nodiscard]] LO GetOwningElementId(const Results& result, int i) override;
+	[[nodiscard]] Kokkos::View<LO*> GetOwningElementIds(const Results& results) override;
 
 private:
-  Omega_h::Mesh mesh_;
-  Omega_h::Adj tris2edges_adj_;
-  Omega_h::Adj tris2verts_adj_;
-  Omega_h::Adj edges2verts_adj_;
-  Omega_h::Adj edges2faces_up_;
-  Omega_h::Adj verts2faces_up_;
-  Kokkos::View<Uniform2DGrid[1]> grid_{"uniform grid"};
-  CandidateMapT candidate_map_;
-  Omega_h::LOs tris2verts_;
-  Omega_h::Reals coords_;
+	Omega_h::Mesh mesh_;
+	Omega_h::Adj tris2edges_adj_;
+	Omega_h::Adj tris2verts_adj_;
+	Omega_h::Adj edges2verts_adj_;
+	Omega_h::Adj edges2faces_up_;
+	Omega_h::Adj verts2faces_up_;
+	Kokkos::View<Uniform2DGrid[1]> grid_{"uniform grid"};
+	CandidateMapT candidate_map_;
+	Omega_h::LOs tris2verts_;
+	Omega_h::Reals coords_;
 };
 
-class GridPointSearch3D : public PointLocalizationSearch3D
+class GridPointSearch3D : public PointSearch
 {
-  using CandidateMapT =
-    Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>;
+	using CandidateMapT =
+		Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>;
 
 public:
-  using Result = PointLocalizationSearch3D::Result;
+	static constexpr int DIM = 3;
 
-  GridPointSearch3D(Omega_h::Mesh& mesh, LO Nx, LO Ny, LO Nz);
-  GridPointSearch3D(Omega_h::Mesh& mesh, LO Nx, LO Ny, LO Nz,
-                    const PointSearchTolerances& tolerances);
+	using Results = PointSearch::Results;
+	using Dimensionality = Results::Dimensionality;
 
-  /**
-   *  Given a point in global coordinates, returns the id of the tetrahedron (3D
-   * element) that the point lies within and the parametric coordinate of the
-   * point within the tetrahedron. If the point does not lie within any
-   * tetrahedron element, then the id will be a negative number and (TODO) will
-   * return a negative id of the closest element.
-   */
-  Kokkos::View<Result*> operator()(
-    Kokkos::View<const Real* [DIM]> point) const override;
-  [[nodiscard]] LO GetOwningElementId(const Result& result) override;
-  [[nodiscard]] Kokkos::View<LO*> GetOwningElementIds(
-    Kokkos::View<const Result*> results) override;
+	GridPointSearch3D(Omega_h::Mesh& mesh, LO Nx, LO Ny, LO Nz);
+	GridPointSearch3D(Omega_h::Mesh& mesh, LO Nx, LO Ny, LO Nz,
+										const PointSearchTolerances& tolerances);
+
+	/**
+	 *  Given a point in global coordinates, returns the id of the tetrahedron (3D
+	 * element) that the point lies within and the parametric coordinate of the
+	 * point within the tetrahedron. If the point does not lie within any
+	 * tetrahedron element, then the id will be a negative number and (TODO) will
+	 * return a negative id of the closest element.
+	 */
+	Results apply(
+		const CoordinateView<MemorySpace>& coords) const override;
+	[[nodiscard]] LO GetOwningElementId(const Results& result, int i) override;
+	[[nodiscard]] Kokkos::View<LO*> GetOwningElementIds(const Results& results) override;
 
 private:
-  Omega_h::Mesh mesh_;
-  Omega_h::Adj tris2edges_adj_;
-  Omega_h::Adj tris2verts_adj_;
-  Omega_h::Adj edges2verts_adj_;
-  Omega_h::Adj verts2regions_up_;
-  Omega_h::Adj edges2regions_up_;
-  Omega_h::Adj faces2regions_up_;
-  Kokkos::View<UniformGrid<DIM>[1]> grid_{"uniform grid"};
-  CandidateMapT candidate_map_;
-  Omega_h::LOs tris2verts_;
-  Omega_h::Reals coords_;
-  Real fuzz_;
+	Omega_h::Mesh mesh_;
+	Omega_h::Adj tris2edges_adj_;
+	Omega_h::Adj tris2verts_adj_;
+	Omega_h::Adj edges2verts_adj_;
+	Omega_h::Adj verts2regions_up_;
+	Omega_h::Adj edges2regions_up_;
+	Omega_h::Adj faces2regions_up_;
+	Kokkos::View<UniformGrid<DIM>[1]> grid_{"uniform grid"};
+	CandidateMapT candidate_map_;
+	Omega_h::LOs tris2verts_;
+	Omega_h::Reals coords_;
+	Real fuzz_;
 };
 
 } // namespace pcms

--- a/src/pcms/localization/point_search.h
+++ b/src/pcms/localization/point_search.h
@@ -195,15 +195,16 @@ public:
 
 private:
 	Omega_h::Mesh mesh_;
-	Omega_h::Adj tris2edges_adj_;
-	Omega_h::Adj tris2verts_adj_;
+	Omega_h::Adj tets2faces_adj_;
+	Omega_h::Adj tets2edges_adj_;
+	Omega_h::Adj tets2verts_adj_;
 	Omega_h::Adj edges2verts_adj_;
 	Omega_h::Adj verts2regions_up_;
 	Omega_h::Adj edges2regions_up_;
 	Omega_h::Adj faces2regions_up_;
 	Kokkos::View<UniformGrid<DIM>[1]> grid_{"uniform grid"};
 	CandidateMapT candidate_map_;
-	Omega_h::LOs tris2verts_;
+	Omega_h::LOs tets2verts_;
 	Omega_h::Reals coords_;
 	Real fuzz_;
 };

--- a/src/pcms/transfer/mesh_intersection.cpp
+++ b/src/pcms/transfer/mesh_intersection.cpp
@@ -29,7 +29,9 @@ void FindIntersections::adjBasedIntersectSearch(
   auto centroids = ConvertCoordsTo2D(flat_centroids, target_mesh_.nfaces(), 2);
 
   pcms::GridPointSearch2D search_cell(source_mesh_, 20, 20);
-  auto results = search_cell(centroids);
+  auto results = search_cell.apply(CoordinateView(
+	CoordinateSystem::Cartesian,
+	MakeConstRank2View(centroids)));
   auto owning_cell_ids = search_cell.GetOwningElementIds(results);
 
   auto nfaces_target = target_mesh_.nfaces();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -399,7 +399,9 @@ if(Catch2_FOUND)
       test_localization_factory.cpp
       test_omega_h_field2_outofbounds.cpp
       test_omega_h_lagrange_field.cpp
-      test_point_evaluator.cpp)
+      test_point_evaluator.cpp
+	  test_tree_localization.cpp
+	)
   endif()
 
   if(PCMS_ENABLE_MESHFIELDS)

--- a/test/test_point_search.cpp
+++ b/test/test_point_search.cpp
@@ -213,13 +213,13 @@ TEST_CASE("uniform grid search")
 	  auto dim = result_dims_h(0);
 	  auto idx = result_ids_h(0);
 	  auto coords = Omega_h::Vector<3>{result_coords_h(0,0), result_coords_h(0,1), result_coords_h(0,2)};
-    //   const auto face_idx = search.GetOwningElementId(results_h(0));
+      const auto face_idx = pcms::GetOwningElementId(mesh, mesh.dim(), static_cast<int>(result_dims_h(0)), result_ids_h(0));
 
       CAPTURE(idx);
 
       REQUIRE(dim == GridPointSearch2D::Results::Dimensionality::VERTEX);
       REQUIRE(idx == 0);
-    //   REQUIRE(face_idx >= 0);
+      REQUIRE(face_idx >= 0);
       REQUIRE(coords[0] == Catch::Approx(1));
       REQUIRE(coords[1] == Catch::Approx(0));
       REQUIRE(coords[2] == Catch::Approx(0));
@@ -228,10 +228,10 @@ TEST_CASE("uniform grid search")
 	  auto dim = result_dims_h(1);
 	  auto idx = result_ids_h(1);
 	  auto coords = Omega_h::Vector<3>{result_coords_h(1,0), result_coords_h(1,1), result_coords_h(1,2)};
-    //   const auto face_idx = search.GetOwningElementId(results_h(1));
+      const auto face_idx = pcms::GetOwningElementId(mesh, mesh.dim(), static_cast<int>(result_dims_h(1)), result_ids_h(1));
       REQUIRE(dim == GridPointSearch2D::Results::Dimensionality::EDGE);
       REQUIRE(idx == 156);
-    //   REQUIRE(face_idx >= 0);
+      REQUIRE(face_idx >= 0);
       REQUIRE(coords[0] == Catch::Approx(0.5));
       REQUIRE(coords[1] == Catch::Approx(0.1));
       REQUIRE(coords[2] == Catch::Approx(0.4));
@@ -239,60 +239,66 @@ TEST_CASE("uniform grid search")
     {
 	  auto dim = result_dims_h(7);
 	  auto idx = result_ids_h(7);
-    //   const auto face_idx = search.GetOwningElementId(results_h(7));
-      REQUIRE(dim == GridPointSearch2D::Results::Dimensionality::FACE); // failed
+      const auto face_idx = pcms::GetOwningElementId(mesh, mesh.dim(), static_cast<int>(result_dims_h(7)), result_ids_h(7));
+      REQUIRE(dim == GridPointSearch2D::Results::Dimensionality::FACE);
       REQUIRE(idx == 0);
-    //   REQUIRE(face_idx >= 0);
+      REQUIRE(face_idx >= 0);
     }
   }
   // feature needs to be added
-//   SECTION("Global coordinate outside mesh", "[!mayfail]")
-//   {
-//     auto out_of_bounds = results_h(2);
-//     auto top_right = results_h(3);
-//     REQUIRE(out_of_bounds.dimensionality ==
-//             GridPointSearch2D::Results::Dimensionality::VERTEX);
-//     REQUIRE(-1 * out_of_bounds.element_id == top_right.element_id);
-//     REQUIRE(search.GetOwningElementId(out_of_bounds) >= 0);
+  SECTION("Global coordinate outside mesh", "[!mayfail]")
+  {
+	auto out_of_bounds_dim = result_dims_h(2);
+    auto out_of_bounds_id = result_ids_h(2);
+    auto top_right_id = result_ids_h(3);
+    REQUIRE(out_of_bounds_dim ==
+            GridPointSearch2D::Results::Dimensionality::VERTEX);
+    REQUIRE(-1 * out_of_bounds_id == top_right_id);
+    REQUIRE(pcms::GetOwningElementId(mesh, mesh.dim(), static_cast<int>(out_of_bounds_dim), -out_of_bounds_id) >= 0);
 
-//     out_of_bounds = results_h(4);
-//     auto bot_left = results_h(0);
-//     REQUIRE(out_of_bounds.dimensionality ==
-//             GridPointSearch2D::Results::Dimensionality::VERTEX);
-//     REQUIRE(-1 * out_of_bounds.element_id == bot_left.element_id);
-//     REQUIRE(search.GetOwningElementId(out_of_bounds) >= 0);
+    out_of_bounds_dim = result_dims_h(4);
+    out_of_bounds_id = result_ids_h(4);
+    auto bot_left_id = result_ids_h(0);
+    REQUIRE(out_of_bounds_dim ==
+            GridPointSearch2D::Results::Dimensionality::VERTEX);
+    REQUIRE(-1 * out_of_bounds_id == bot_left_id);
+    REQUIRE(pcms::GetOwningElementId(mesh, mesh.dim(), static_cast<int>(out_of_bounds_dim), -out_of_bounds_id) >= 0);
 
-//     out_of_bounds = results_h(5);
-//     REQUIRE(out_of_bounds.dimensionality ==
-//             GridPointSearch2D::Results::Dimensionality::EDGE);
-//     REQUIRE(out_of_bounds.element_id == -219);
-//     REQUIRE(search.GetOwningElementId(out_of_bounds) >= 0);
+	out_of_bounds_dim = result_dims_h(5);
+    out_of_bounds_id = result_ids_h(5);
+    REQUIRE(out_of_bounds_dim ==
+            GridPointSearch2D::Results::Dimensionality::EDGE);
+    REQUIRE(out_of_bounds_id == -219);
+    REQUIRE(pcms::GetOwningElementId(mesh, mesh.dim(), static_cast<int>(out_of_bounds_dim), -out_of_bounds_id) >= 0);
 
-//     out_of_bounds = results_h(6);
-//     REQUIRE(out_of_bounds.dimensionality ==
-//             GridPointSearch2D::Results::Dimensionality::EDGE);
-//     REQUIRE(-1 * out_of_bounds.element_id == bot_left.element_id);
-//     REQUIRE(search.GetOwningElementId(out_of_bounds) >= 0);
-//   }
-//   SECTION("point on extension of an edge")
-//   {
-//     Kokkos::View<pcms::Real* [2]> ext_points("ext_test_points", 1);
-//     auto ext_h = Kokkos::create_mirror_view(ext_points);
-//     ext_h(0, 0) = 1.5;
-//     ext_h(0, 1) = 0.0;
-//     Kokkos::deep_copy(ext_points, ext_h);
-//     auto ext_results = search(ext_points);
-//     auto ext_results_h = Kokkos::create_mirror_view(ext_results);
-//     Kokkos::deep_copy(ext_results_h, ext_results);
+    out_of_bounds_dim = result_dims_h(6);
+    out_of_bounds_id = result_ids_h(6);
+    REQUIRE(out_of_bounds_dim ==
+            GridPointSearch2D::Results::Dimensionality::EDGE);
+    REQUIRE(-1 * out_of_bounds_id == bot_left_id);
+    REQUIRE(pcms::GetOwningElementId(mesh, mesh.dim(), static_cast<int>(out_of_bounds_dim), -out_of_bounds_id) >= 0);
+  }
+  SECTION("point on extension of an edge")
+  {
+    Kokkos::View<pcms::Real**> ext_points("ext_test_points", 1, 2);
+    auto ext_h = Kokkos::create_mirror_view(ext_points);
+    ext_h(0, 0) = 1.5;
+    ext_h(0, 1) = 0.0;
+    Kokkos::deep_copy(ext_points, ext_h);
+    auto ext_results = search.apply(pcms::CoordinateView(pcms::CoordinateSystem::Cartesian, 
+		pcms::MakeConstRank2View(ext_points)));
 
-//     auto res = ext_results_h(0);
-//     // Must be out-of-bounds (negative element id)
-//     REQUIRE(res.element_id < 0);
-//     // Dimensionality must be VERTEX — the nearest entity is the
-//     // rightmost bottom vertex (1.0, 0).
-//     REQUIRE(res.dimensionality ==
-//             GridPointSearch2D::Results::Dimensionality::VERTEX);
-//     // Owning element should still resolve to a valid face
-//     REQUIRE(search.GetOwningElementId(res) >= 0);
-//   }
+	auto result_dims_h = Kokkos::create_mirror_view(ext_results.dimensionalities);
+	Kokkos::deep_copy(result_dims_h, ext_results.dimensionalities);
+	auto result_ids_h = Kokkos::create_mirror_view(ext_results.element_ids);
+	Kokkos::deep_copy(result_ids_h, ext_results.element_ids);
+    // Must be out-of-bounds (negative element id)
+    REQUIRE(result_ids_h(0) < 0);
+    // Dimensionality must be VERTEX — the nearest entity is the
+    // rightmost bottom vertex (1.0, 0).
+    REQUIRE(result_dims_h(0) ==
+            GridPointSearch2D::Results::Dimensionality::VERTEX);
+    // Owning element should still resolve to a valid face
+    REQUIRE(pcms::GetOwningElementId(mesh, mesh.dim(), 0, -result_ids_h(0)) >= 0);
+  }
 }

--- a/test/test_point_search.cpp
+++ b/test/test_point_search.cpp
@@ -170,7 +170,7 @@ TEST_CASE("uniform grid search")
   auto mesh =
     Omega_h::build_box(world, OMEGA_H_SIMPLEX, 1, 1, 1, 10, 10, 0, false);
   auto tolerances =
-    GridPointSearch2D::PointSearchTolerances{"point search 2d tolerances"};
+    GridPointSearch2D::PointSearchTolerances("point search 2d tolerances", 2);
   auto tolerances_h = Kokkos::create_mirror_view(tolerances);
   tolerances_h(0) = 0.01;
   tolerances_h(1) = 0.01;
@@ -178,7 +178,7 @@ TEST_CASE("uniform grid search")
 
   GridPointSearch2D search{mesh, 10, 10, tolerances};
 
-  Kokkos::View<pcms::Real* [2]> points("test_points", 8);
+  Kokkos::View<pcms::Real**> points("test_points", 8, 2);
   // Kokkos::View<pcms::Real*[2]> points("test_points", 1);
   auto points_h = Kokkos::create_mirror_view(points);
   points_h(0, 0) = 0;
@@ -198,90 +198,101 @@ TEST_CASE("uniform grid search")
   points_h(7, 0) = 0.05;
   points_h(7, 1) = 0.02;
   Kokkos::deep_copy(points, points_h);
-  auto results = search(points);
-  auto results_h = Kokkos::create_mirror_view(results);
-  Kokkos::deep_copy(results_h, results);
+  auto results = search.apply(
+	pcms::CoordinateView(pcms::CoordinateSystem::Cartesian, 
+		pcms::MakeConstRank2View(points)));
+  auto result_dims_h = Kokkos::create_mirror_view(results.dimensionalities);
+  Kokkos::deep_copy(result_dims_h, results.dimensionalities);
+  auto result_ids_h = Kokkos::create_mirror_view(results.element_ids);
+  Kokkos::deep_copy(result_ids_h, results.element_ids);
+  auto result_coords_h = Kokkos::create_mirror_view(results.parametric_coords);
+  Kokkos::deep_copy(result_coords_h, results.parametric_coords);
   SECTION("global coordinate within mesh")
   {
     {
-      auto [dim, idx, coords] = results_h(0);
-      const auto face_idx = search.GetOwningElementId(results_h(0));
+	  auto dim = result_dims_h(0);
+	  auto idx = result_ids_h(0);
+	  auto coords = Omega_h::Vector<3>{result_coords_h(0,0), result_coords_h(0,1), result_coords_h(0,2)};
+    //   const auto face_idx = search.GetOwningElementId(results_h(0));
 
       CAPTURE(idx);
 
-      REQUIRE(dim == GridPointSearch2D::Result::Dimensionality::VERTEX);
+      REQUIRE(dim == GridPointSearch2D::Results::Dimensionality::VERTEX);
       REQUIRE(idx == 0);
-      REQUIRE(face_idx >= 0);
+    //   REQUIRE(face_idx >= 0);
       REQUIRE(coords[0] == Catch::Approx(1));
       REQUIRE(coords[1] == Catch::Approx(0));
       REQUIRE(coords[2] == Catch::Approx(0));
     }
     {
-      auto [dim, idx, coords] = results_h(1);
-      const auto face_idx = search.GetOwningElementId(results_h(1));
-      REQUIRE(dim == GridPointSearch2D::Result::Dimensionality::EDGE);
+	  auto dim = result_dims_h(1);
+	  auto idx = result_ids_h(1);
+	  auto coords = Omega_h::Vector<3>{result_coords_h(1,0), result_coords_h(1,1), result_coords_h(1,2)};
+    //   const auto face_idx = search.GetOwningElementId(results_h(1));
+      REQUIRE(dim == GridPointSearch2D::Results::Dimensionality::EDGE);
       REQUIRE(idx == 156);
-      REQUIRE(face_idx >= 0);
+    //   REQUIRE(face_idx >= 0);
       REQUIRE(coords[0] == Catch::Approx(0.5));
       REQUIRE(coords[1] == Catch::Approx(0.1));
       REQUIRE(coords[2] == Catch::Approx(0.4));
     }
     {
-      auto [dim, idx, coords] = results_h(7);
-      const auto face_idx = search.GetOwningElementId(results_h(7));
-      REQUIRE(dim == GridPointSearch2D::Result::Dimensionality::FACE);
+	  auto dim = result_dims_h(7);
+	  auto idx = result_ids_h(7);
+    //   const auto face_idx = search.GetOwningElementId(results_h(7));
+      REQUIRE(dim == GridPointSearch2D::Results::Dimensionality::FACE); // failed
       REQUIRE(idx == 0);
-      REQUIRE(face_idx >= 0);
+    //   REQUIRE(face_idx >= 0);
     }
   }
   // feature needs to be added
-  SECTION("Global coordinate outside mesh", "[!mayfail]")
-  {
-    auto out_of_bounds = results_h(2);
-    auto top_right = results_h(3);
-    REQUIRE(out_of_bounds.dimensionality ==
-            GridPointSearch2D::Result::Dimensionality::VERTEX);
-    REQUIRE(-1 * out_of_bounds.element_id == top_right.element_id);
-    REQUIRE(search.GetOwningElementId(out_of_bounds) >= 0);
+//   SECTION("Global coordinate outside mesh", "[!mayfail]")
+//   {
+//     auto out_of_bounds = results_h(2);
+//     auto top_right = results_h(3);
+//     REQUIRE(out_of_bounds.dimensionality ==
+//             GridPointSearch2D::Results::Dimensionality::VERTEX);
+//     REQUIRE(-1 * out_of_bounds.element_id == top_right.element_id);
+//     REQUIRE(search.GetOwningElementId(out_of_bounds) >= 0);
 
-    out_of_bounds = results_h(4);
-    auto bot_left = results_h(0);
-    REQUIRE(out_of_bounds.dimensionality ==
-            GridPointSearch2D::Result::Dimensionality::VERTEX);
-    REQUIRE(-1 * out_of_bounds.element_id == bot_left.element_id);
-    REQUIRE(search.GetOwningElementId(out_of_bounds) >= 0);
+//     out_of_bounds = results_h(4);
+//     auto bot_left = results_h(0);
+//     REQUIRE(out_of_bounds.dimensionality ==
+//             GridPointSearch2D::Results::Dimensionality::VERTEX);
+//     REQUIRE(-1 * out_of_bounds.element_id == bot_left.element_id);
+//     REQUIRE(search.GetOwningElementId(out_of_bounds) >= 0);
 
-    out_of_bounds = results_h(5);
-    REQUIRE(out_of_bounds.dimensionality ==
-            GridPointSearch2D::Result::Dimensionality::EDGE);
-    REQUIRE(out_of_bounds.element_id == -219);
-    REQUIRE(search.GetOwningElementId(out_of_bounds) >= 0);
+//     out_of_bounds = results_h(5);
+//     REQUIRE(out_of_bounds.dimensionality ==
+//             GridPointSearch2D::Results::Dimensionality::EDGE);
+//     REQUIRE(out_of_bounds.element_id == -219);
+//     REQUIRE(search.GetOwningElementId(out_of_bounds) >= 0);
 
-    out_of_bounds = results_h(6);
-    REQUIRE(out_of_bounds.dimensionality ==
-            GridPointSearch2D::Result::Dimensionality::EDGE);
-    REQUIRE(-1 * out_of_bounds.element_id == bot_left.element_id);
-    REQUIRE(search.GetOwningElementId(out_of_bounds) >= 0);
-  }
-  SECTION("point on extension of an edge")
-  {
-    Kokkos::View<pcms::Real* [2]> ext_points("ext_test_points", 1);
-    auto ext_h = Kokkos::create_mirror_view(ext_points);
-    ext_h(0, 0) = 1.5;
-    ext_h(0, 1) = 0.0;
-    Kokkos::deep_copy(ext_points, ext_h);
-    auto ext_results = search(ext_points);
-    auto ext_results_h = Kokkos::create_mirror_view(ext_results);
-    Kokkos::deep_copy(ext_results_h, ext_results);
+//     out_of_bounds = results_h(6);
+//     REQUIRE(out_of_bounds.dimensionality ==
+//             GridPointSearch2D::Results::Dimensionality::EDGE);
+//     REQUIRE(-1 * out_of_bounds.element_id == bot_left.element_id);
+//     REQUIRE(search.GetOwningElementId(out_of_bounds) >= 0);
+//   }
+//   SECTION("point on extension of an edge")
+//   {
+//     Kokkos::View<pcms::Real* [2]> ext_points("ext_test_points", 1);
+//     auto ext_h = Kokkos::create_mirror_view(ext_points);
+//     ext_h(0, 0) = 1.5;
+//     ext_h(0, 1) = 0.0;
+//     Kokkos::deep_copy(ext_points, ext_h);
+//     auto ext_results = search(ext_points);
+//     auto ext_results_h = Kokkos::create_mirror_view(ext_results);
+//     Kokkos::deep_copy(ext_results_h, ext_results);
 
-    auto res = ext_results_h(0);
-    // Must be out-of-bounds (negative element id)
-    REQUIRE(res.element_id < 0);
-    // Dimensionality must be VERTEX — the nearest entity is the
-    // rightmost bottom vertex (1.0, 0).
-    REQUIRE(res.dimensionality ==
-            GridPointSearch2D::Result::Dimensionality::VERTEX);
-    // Owning element should still resolve to a valid face
-    REQUIRE(search.GetOwningElementId(res) >= 0);
-  }
+//     auto res = ext_results_h(0);
+//     // Must be out-of-bounds (negative element id)
+//     REQUIRE(res.element_id < 0);
+//     // Dimensionality must be VERTEX — the nearest entity is the
+//     // rightmost bottom vertex (1.0, 0).
+//     REQUIRE(res.dimensionality ==
+//             GridPointSearch2D::Results::Dimensionality::VERTEX);
+//     // Owning element should still resolve to a valid face
+//     REQUIRE(search.GetOwningElementId(res) >= 0);
+//   }
 }

--- a/test/test_point_search.cpp
+++ b/test/test_point_search.cpp
@@ -162,7 +162,7 @@ TEST_CASE("construct intersection map")
     REQUIRE(num_candidates_within_range(intersection_map, 1, 6));
   }
 }
-TEST_CASE("uniform grid search")
+TEST_CASE("uniform grid search 2D")
 {
   using pcms::GridPointSearch2D;
   auto lib = Omega_h::Library{};
@@ -288,10 +288,10 @@ TEST_CASE("uniform grid search")
     auto ext_results = search.apply(pcms::CoordinateView(pcms::CoordinateSystem::Cartesian, 
 		pcms::MakeConstRank2View(ext_points)));
 
-	auto result_dims_h = Kokkos::create_mirror_view(ext_results.dimensionalities);
-	Kokkos::deep_copy(result_dims_h, ext_results.dimensionalities);
-	auto result_ids_h = Kokkos::create_mirror_view(ext_results.element_ids);
-	Kokkos::deep_copy(result_ids_h, ext_results.element_ids);
+    auto result_dims_h = Kokkos::create_mirror_view(ext_results.dimensionalities);
+    Kokkos::deep_copy(result_dims_h, ext_results.dimensionalities);
+    auto result_ids_h = Kokkos::create_mirror_view(ext_results.element_ids);
+    Kokkos::deep_copy(result_ids_h, ext_results.element_ids);
     // Must be out-of-bounds (negative element id)
     REQUIRE(result_ids_h(0) < 0);
     // Dimensionality must be VERTEX — the nearest entity is the
@@ -301,4 +301,115 @@ TEST_CASE("uniform grid search")
     // Owning element should still resolve to a valid face
     REQUIRE(pcms::GetOwningElementId(mesh, mesh.dim(), 0, -result_ids_h(0)) >= 0);
   }
+}
+TEST_CASE("uniform grid search 3D")
+{
+  using pcms::GridPointSearch3D;
+  auto lib = Omega_h::Library{};
+  auto world = lib.world();
+  auto mesh =
+    Omega_h::build_box(world, OMEGA_H_SIMPLEX, 1, 1, 1, 1, 1, 1, false);
+  auto tolerances =
+    GridPointSearch3D::PointSearchTolerances("point search 3d tolerances", 3);
+  auto tolerances_h = Kokkos::create_mirror_view(tolerances);
+  tolerances_h(0) = 0.01;
+  tolerances_h(1) = 0.01;
+  tolerances_h(2) = 0.01;
+  Kokkos::deep_copy(tolerances, tolerances_h);
+
+  GridPointSearch3D search{mesh, 5, 5, 5, tolerances};
+
+  auto check_res = [] (auto const& results, int dim)
+	{
+		auto dims = Kokkos::create_mirror_view(results.dimensionalities);
+		auto ids = Kokkos::create_mirror_view(results.element_ids);
+		Kokkos::deep_copy(dims, results.dimensionalities);
+		Kokkos::deep_copy(ids, results.element_ids);
+		for (int i = 0; i < dims.size(); i++)
+		{
+			CHECK(dims(i) == (pcms::PointSearch::Results::Dimensionality)dim);
+			CHECK(ids(i) == i);
+			// CHECK_THAT(results(i).parametric_coords,
+			// 	Catch::Matchers::Contains(Catch::Matchers::WithinAbs(1.0, 10e-7)));
+		}
+	};
+  SECTION ("Vertex intersection") {
+		Kokkos::View<pcms::Real**> coords("vertex coordinates", mesh.nverts(), 3);
+		auto coords_h = Kokkos::create_mirror_view(coords);
+		auto meshcoords = Omega_h::HostRead(mesh.coords());
+		for (int i = 0; i < mesh.nverts(); i++)
+		{
+			coords_h(i, 0) = meshcoords[i*3];
+			coords_h(i, 1) = meshcoords[i*3 + 1];
+			coords_h(i, 2) = meshcoords[i*3 + 2];
+		}
+		Kokkos::deep_copy(coords, coords_h);
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> vert_cv(
+			pcms::CoordinateSystem::Cartesian,
+			pcms::MakeConstRank2View(coords));
+		pcms::PointSearch::Results results = search.apply(vert_cv);
+		
+		check_res(results, 0);
+	}
+	SECTION ("Edge intersection") {
+		Kokkos::View<pcms::Real**> coords("intersection coords", mesh.nedges(), 3);
+		auto edge2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::EDGE, Omega_h::VERT).ab2b);
+		auto meshcoords = Omega_h::HostRead(mesh.coords());
+		auto coords_h = Kokkos::create_mirror_view(coords);
+
+		for (int i = 0; i < mesh.nedges(); i++)
+		{
+			Omega_h::Vector<3> v0{
+				meshcoords[edge2vert[2*i]*3], meshcoords[edge2vert[2*i]*3 + 1], meshcoords[edge2vert[2*i]*3 + 2]
+			};
+			Omega_h::Vector<3> v1{
+				meshcoords[edge2vert[2*i + 1]*3], meshcoords[edge2vert[2*i + 1]*3 + 1], meshcoords[edge2vert[2*i + 1]*3 + 2]
+			};
+			Omega_h::Vector<3> midpoint = (v0 + v1)/2.;
+			coords_h(i, 0) = midpoint[0];
+			coords_h(i, 1) = midpoint[1];
+			coords_h(i, 2) = midpoint[2];
+		}
+
+		Kokkos::deep_copy(coords, coords_h);
+
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> edge_cv(
+			pcms::CoordinateSystem::Cartesian,
+			pcms::MakeConstRank2View(coords));
+		pcms::PointSearch::Results results = search.apply(edge_cv);
+		check_res(results, 1);
+	}
+  SECTION ("Region intersection") {
+		Kokkos::View<pcms::Real**> coords("intersection coords", mesh.nelems(), 3);
+    auto region2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::REGION, Omega_h::VERT).ab2b);
+		auto meshcoords = Omega_h::HostRead(mesh.coords());
+		auto coords_h = Kokkos::create_mirror_view(coords);
+
+		for (unsigned i = 0; i < mesh.nelems(); i++)
+		{
+      Omega_h::Vector<3> v0{
+				meshcoords[region2vert[4*i]*3], meshcoords[region2vert[4*i]*3 + 1], meshcoords[region2vert[4*i]*3 + 2]
+			};
+			Omega_h::Vector<3> v1{
+				meshcoords[region2vert[4*i + 1]*3], meshcoords[region2vert[4*i + 1]*3 + 1], meshcoords[region2vert[4*i + 1]*3 + 2]
+			};
+			Omega_h::Vector<3> v2{
+				meshcoords[region2vert[4*i + 2]*3], meshcoords[region2vert[4*i + 2]*3 + 1], meshcoords[region2vert[4*i + 2]*3 + 2]
+			};
+			Omega_h::Vector<3> v3{
+				meshcoords[region2vert[4*i + 3]*3], meshcoords[region2vert[4*i + 3]*3 + 1], meshcoords[region2vert[4*i + 3]*3 + 2]
+			};
+			Omega_h::Vector<3> midpoint = (v0 + v1 + v2 + v3)/4.;
+			coords_h(i, 0) = midpoint[0];
+			coords_h(i, 1) = midpoint[1];
+			coords_h(i, 2) = midpoint[2];
+		}
+		Kokkos::deep_copy(coords, coords_h);
+
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> region_cv(
+			pcms::CoordinateSystem::Cartesian,
+			pcms::MakeConstRank2View(coords));
+		pcms::PointSearch::Results results = search.apply(region_cv);
+		check_res(results, 3);
+	}
 }

--- a/test/test_point_search.cpp
+++ b/test/test_point_search.cpp
@@ -333,83 +333,113 @@ TEST_CASE("uniform grid search 3D")
 			// 	Catch::Matchers::Contains(Catch::Matchers::WithinAbs(1.0, 10e-7)));
 		}
 	};
-  SECTION ("Vertex intersection") {
-		Kokkos::View<pcms::Real**> coords("vertex coordinates", mesh.nverts(), 3);
-		auto coords_h = Kokkos::create_mirror_view(coords);
-		auto meshcoords = Omega_h::HostRead(mesh.coords());
-		for (int i = 0; i < mesh.nverts(); i++)
-		{
-			coords_h(i, 0) = meshcoords[i*3];
-			coords_h(i, 1) = meshcoords[i*3 + 1];
-			coords_h(i, 2) = meshcoords[i*3 + 2];
-		}
-		Kokkos::deep_copy(coords, coords_h);
-		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> vert_cv(
-			pcms::CoordinateSystem::Cartesian,
-			pcms::MakeConstRank2View(coords));
-		pcms::PointSearch::Results results = search.apply(vert_cv);
+//   SECTION ("Vertex intersection") {
+// 		Kokkos::View<pcms::Real**> coords("vertex coordinates", mesh.nverts(), 3);
+// 		auto coords_h = Kokkos::create_mirror_view(coords);
+// 		auto meshcoords = Omega_h::HostRead(mesh.coords());
+// 		for (int i = 0; i < mesh.nverts(); i++)
+// 		{
+// 			coords_h(i, 0) = meshcoords[i*3];
+// 			coords_h(i, 1) = meshcoords[i*3 + 1];
+// 			coords_h(i, 2) = meshcoords[i*3 + 2];
+// 		}
+// 		Kokkos::deep_copy(coords, coords_h);
+// 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> vert_cv(
+// 			pcms::CoordinateSystem::Cartesian,
+// 			pcms::MakeConstRank2View(coords));
+// 		pcms::PointSearch::Results results = search.apply(vert_cv);
 		
-		check_res(results, 0);
-	}
-	SECTION ("Edge intersection") {
-		Kokkos::View<pcms::Real**> coords("intersection coords", mesh.nedges(), 3);
-		auto edge2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::EDGE, Omega_h::VERT).ab2b);
+// 		check_res(results, 0);
+// 	}
+	// SECTION ("Edge intersection") {
+	// 	Kokkos::View<pcms::Real**> coords("intersection coords", mesh.nedges(), 3);
+	// 	auto edge2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::EDGE, Omega_h::VERT).ab2b);
+	// 	auto meshcoords = Omega_h::HostRead(mesh.coords());
+	// 	auto coords_h = Kokkos::create_mirror_view(coords);
+
+	// 	for (int i = 0; i < mesh.nedges(); i++)
+	// 	{
+	// 		Omega_h::Vector<3> v0{
+	// 			meshcoords[edge2vert[2*i]*3], meshcoords[edge2vert[2*i]*3 + 1], meshcoords[edge2vert[2*i]*3 + 2]
+	// 		};
+	// 		Omega_h::Vector<3> v1{
+	// 			meshcoords[edge2vert[2*i + 1]*3], meshcoords[edge2vert[2*i + 1]*3 + 1], meshcoords[edge2vert[2*i + 1]*3 + 2]
+	// 		};
+	// 		Omega_h::Vector<3> midpoint = (v0 + v1)/2.;
+	// 		coords_h(i, 0) = midpoint[0];
+	// 		coords_h(i, 1) = midpoint[1];
+	// 		coords_h(i, 2) = midpoint[2];
+	// 	}
+
+	// 	Kokkos::deep_copy(coords, coords_h);
+
+	// 	pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> edge_cv(
+	// 		pcms::CoordinateSystem::Cartesian,
+	// 		pcms::MakeConstRank2View(coords));
+	// 	pcms::PointSearch::Results results = search.apply(edge_cv);
+	// 	check_res(results, 1);
+	// }
+	SECTION ("Face intersection") {
+		Kokkos::View<pcms::Real**> coords("intersection coords", mesh.nfaces(), 3);
+		auto face2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::FACE, Omega_h::VERT).ab2b);
 		auto meshcoords = Omega_h::HostRead(mesh.coords());
 		auto coords_h = Kokkos::create_mirror_view(coords);
 
-		for (int i = 0; i < mesh.nedges(); i++)
+		for (int i = 0; i < mesh.nfaces(); i++)
 		{
 			Omega_h::Vector<3> v0{
-				meshcoords[edge2vert[2*i]*3], meshcoords[edge2vert[2*i]*3 + 1], meshcoords[edge2vert[2*i]*3 + 2]
+				meshcoords[face2vert[3*i]*3], meshcoords[face2vert[3*i]*3 + 1], meshcoords[face2vert[3*i]*3 + 2]
 			};
 			Omega_h::Vector<3> v1{
-				meshcoords[edge2vert[2*i + 1]*3], meshcoords[edge2vert[2*i + 1]*3 + 1], meshcoords[edge2vert[2*i + 1]*3 + 2]
-			};
-			Omega_h::Vector<3> midpoint = (v0 + v1)/2.;
-			coords_h(i, 0) = midpoint[0];
-			coords_h(i, 1) = midpoint[1];
-			coords_h(i, 2) = midpoint[2];
-		}
-
-		Kokkos::deep_copy(coords, coords_h);
-
-		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> edge_cv(
-			pcms::CoordinateSystem::Cartesian,
-			pcms::MakeConstRank2View(coords));
-		pcms::PointSearch::Results results = search.apply(edge_cv);
-		check_res(results, 1);
-	}
-  SECTION ("Region intersection") {
-		Kokkos::View<pcms::Real**> coords("intersection coords", mesh.nelems(), 3);
-    auto region2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::REGION, Omega_h::VERT).ab2b);
-		auto meshcoords = Omega_h::HostRead(mesh.coords());
-		auto coords_h = Kokkos::create_mirror_view(coords);
-
-		for (unsigned i = 0; i < mesh.nelems(); i++)
-		{
-      Omega_h::Vector<3> v0{
-				meshcoords[region2vert[4*i]*3], meshcoords[region2vert[4*i]*3 + 1], meshcoords[region2vert[4*i]*3 + 2]
-			};
-			Omega_h::Vector<3> v1{
-				meshcoords[region2vert[4*i + 1]*3], meshcoords[region2vert[4*i + 1]*3 + 1], meshcoords[region2vert[4*i + 1]*3 + 2]
+				meshcoords[face2vert[3*i + 1]*3], meshcoords[face2vert[3*i + 1]*3 + 1], meshcoords[face2vert[3*i + 1]*3 + 2]
 			};
 			Omega_h::Vector<3> v2{
-				meshcoords[region2vert[4*i + 2]*3], meshcoords[region2vert[4*i + 2]*3 + 1], meshcoords[region2vert[4*i + 2]*3 + 2]
+				meshcoords[face2vert[3*i + 2]*3], meshcoords[face2vert[3*i + 2]*3 + 1], meshcoords[face2vert[3*i + 2]*3 + 2]
 			};
-			Omega_h::Vector<3> v3{
-				meshcoords[region2vert[4*i + 3]*3], meshcoords[region2vert[4*i + 3]*3 + 1], meshcoords[region2vert[4*i + 3]*3 + 2]
-			};
-			Omega_h::Vector<3> midpoint = (v0 + v1 + v2 + v3)/4.;
+			Omega_h::Vector<3> midpoint = (v0 + v1 + v2)/3.;
 			coords_h(i, 0) = midpoint[0];
 			coords_h(i, 1) = midpoint[1];
 			coords_h(i, 2) = midpoint[2];
 		}
 		Kokkos::deep_copy(coords, coords_h);
 
-		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> region_cv(
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> face_cv(
 			pcms::CoordinateSystem::Cartesian,
 			pcms::MakeConstRank2View(coords));
-		pcms::PointSearch::Results results = search.apply(region_cv);
-		check_res(results, 3);
+		pcms::GridPointSearch3D::Results results = search.apply(face_cv);
+		check_res(results, 2);
 	}
+//   SECTION ("Region intersection") {
+// 		Kokkos::View<pcms::Real**> coords("intersection coords", mesh.nelems(), 3);
+//     auto region2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::REGION, Omega_h::VERT).ab2b);
+// 		auto meshcoords = Omega_h::HostRead(mesh.coords());
+// 		auto coords_h = Kokkos::create_mirror_view(coords);
+
+// 		for (unsigned i = 0; i < mesh.nelems(); i++)
+// 		{
+//       Omega_h::Vector<3> v0{
+// 				meshcoords[region2vert[4*i]*3], meshcoords[region2vert[4*i]*3 + 1], meshcoords[region2vert[4*i]*3 + 2]
+// 			};
+// 			Omega_h::Vector<3> v1{
+// 				meshcoords[region2vert[4*i + 1]*3], meshcoords[region2vert[4*i + 1]*3 + 1], meshcoords[region2vert[4*i + 1]*3 + 2]
+// 			};
+// 			Omega_h::Vector<3> v2{
+// 				meshcoords[region2vert[4*i + 2]*3], meshcoords[region2vert[4*i + 2]*3 + 1], meshcoords[region2vert[4*i + 2]*3 + 2]
+// 			};
+// 			Omega_h::Vector<3> v3{
+// 				meshcoords[region2vert[4*i + 3]*3], meshcoords[region2vert[4*i + 3]*3 + 1], meshcoords[region2vert[4*i + 3]*3 + 2]
+// 			};
+// 			Omega_h::Vector<3> midpoint = (v0 + v1 + v2 + v3)/4.;
+// 			coords_h(i, 0) = midpoint[0];
+// 			coords_h(i, 1) = midpoint[1];
+// 			coords_h(i, 2) = midpoint[2];
+// 		}
+// 		Kokkos::deep_copy(coords, coords_h);
+
+// 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> region_cv(
+// 			pcms::CoordinateSystem::Cartesian,
+// 			pcms::MakeConstRank2View(coords));
+// 		pcms::PointSearch::Results results = search.apply(region_cv);
+// 		check_res(results, 3);
+	// }
 }

--- a/test/test_point_search.cpp
+++ b/test/test_point_search.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 #include <pcms/localization/point_search.h>
+#include <pcms/localization/point_localization.h>
 #include <Omega_h_mesh.hpp>
 #include <Omega_h_build.hpp>
 
@@ -164,19 +165,19 @@ TEST_CASE("construct intersection map")
 }
 TEST_CASE("uniform grid search 2D")
 {
-  using pcms::GridPointSearch2D;
+  using pcms::PointSearch;
   auto lib = Omega_h::Library{};
   auto world = lib.world();
   auto mesh =
     Omega_h::build_box(world, OMEGA_H_SIMPLEX, 1, 1, 1, 10, 10, 0, false);
   auto tolerances =
-    GridPointSearch2D::PointSearchTolerances("point search 2d tolerances", 2);
+    pcms::PointSearch::PointSearchTolerances("point search 2d tolerances", 2);
   auto tolerances_h = Kokkos::create_mirror_view(tolerances);
   tolerances_h(0) = 0.01;
   tolerances_h(1) = 0.01;
   Kokkos::deep_copy(tolerances, tolerances_h);
 
-  GridPointSearch2D search{mesh, 10, 10, tolerances};
+  std::unique_ptr<pcms::PointSearch> search = std::make_unique<pcms::GridPointSearch2D>(mesh, 10, 10, tolerances);
 
   Kokkos::View<pcms::Real**> points("test_points", 8, 2);
   // Kokkos::View<pcms::Real*[2]> points("test_points", 1);
@@ -198,9 +199,9 @@ TEST_CASE("uniform grid search 2D")
   points_h(7, 0) = 0.05;
   points_h(7, 1) = 0.02;
   Kokkos::deep_copy(points, points_h);
-  auto results = search.apply(
-	pcms::CoordinateView(pcms::CoordinateSystem::Cartesian, 
-		pcms::MakeConstRank2View(points)));
+  auto results = search->apply(
+  pcms::CoordinateView(pcms::CoordinateSystem::Cartesian, 
+    pcms::MakeConstRank2View(points)));
   auto result_dims_h = Kokkos::create_mirror_view(results.dimensionalities);
   Kokkos::deep_copy(result_dims_h, results.dimensionalities);
   auto result_ids_h = Kokkos::create_mirror_view(results.element_ids);
@@ -210,37 +211,37 @@ TEST_CASE("uniform grid search 2D")
   SECTION("global coordinate within mesh")
   {
     {
-	  auto dim = result_dims_h(0);
-	  auto idx = result_ids_h(0);
-	  auto coords = Omega_h::Vector<3>{result_coords_h(0,0), result_coords_h(0,1), result_coords_h(0,2)};
-      const auto face_idx = pcms::GetOwningElementId(mesh, mesh.dim(), static_cast<int>(result_dims_h(0)), result_ids_h(0));
+    auto dim = result_dims_h(0);
+    auto idx = result_ids_h(0);
+    auto coords = Omega_h::Vector<3>{result_coords_h(0,0), result_coords_h(0,1), result_coords_h(0,2)};
+      const auto face_idx = search->GetOwningElementId(results, 0);
 
       CAPTURE(idx);
 
-      REQUIRE(dim == GridPointSearch2D::Results::Dimensionality::VERTEX);
+      REQUIRE(dim == PointSearch::Results::Dimensionality::VERTEX);
       REQUIRE(idx == 0);
       REQUIRE(face_idx >= 0);
-      REQUIRE(coords[0] == Catch::Approx(1));
-      REQUIRE(coords[1] == Catch::Approx(0));
-      REQUIRE(coords[2] == Catch::Approx(0));
+      REQUIRE(coords[0] == Catch::Approx(1).margin(0.00001));
+      REQUIRE(coords[1] == Catch::Approx(0).margin(0.00001));
+      REQUIRE(coords[2] == Catch::Approx(0).margin(0.00001));
     }
     {
-	  auto dim = result_dims_h(1);
-	  auto idx = result_ids_h(1);
-	  auto coords = Omega_h::Vector<3>{result_coords_h(1,0), result_coords_h(1,1), result_coords_h(1,2)};
-      const auto face_idx = pcms::GetOwningElementId(mesh, mesh.dim(), static_cast<int>(result_dims_h(1)), result_ids_h(1));
-      REQUIRE(dim == GridPointSearch2D::Results::Dimensionality::EDGE);
+    auto dim = result_dims_h(1);
+    auto idx = result_ids_h(1);
+    auto coords = Omega_h::Vector<3>{result_coords_h(1,0), result_coords_h(1,1), result_coords_h(1,2)};
+      const auto face_idx = search->GetOwningElementId(results, 1);
+      REQUIRE(dim == PointSearch::Results::Dimensionality::EDGE);
       REQUIRE(idx == 156);
       REQUIRE(face_idx >= 0);
-      REQUIRE(coords[0] == Catch::Approx(0.5));
-      REQUIRE(coords[1] == Catch::Approx(0.1));
-      REQUIRE(coords[2] == Catch::Approx(0.4));
+      REQUIRE(coords[0] == Catch::Approx(0.5).margin(0.00001));
+      REQUIRE(coords[1] == Catch::Approx(0.1).margin(0.00001));
+      REQUIRE(coords[2] == Catch::Approx(0.4).margin(0.00001));
     }
     {
-	  auto dim = result_dims_h(7);
-	  auto idx = result_ids_h(7);
-      const auto face_idx = pcms::GetOwningElementId(mesh, mesh.dim(), static_cast<int>(result_dims_h(7)), result_ids_h(7));
-      REQUIRE(dim == GridPointSearch2D::Results::Dimensionality::FACE);
+    auto dim = result_dims_h(7);
+    auto idx = result_ids_h(7);
+      const auto face_idx = search->GetOwningElementId(results, 7);
+      REQUIRE(dim == PointSearch::Results::Dimensionality::FACE);
       REQUIRE(idx == 0);
       REQUIRE(face_idx >= 0);
     }
@@ -248,35 +249,35 @@ TEST_CASE("uniform grid search 2D")
   // feature needs to be added
   SECTION("Global coordinate outside mesh", "[!mayfail]")
   {
-	auto out_of_bounds_dim = result_dims_h(2);
+    auto out_of_bounds_dim = result_dims_h(2);
     auto out_of_bounds_id = result_ids_h(2);
     auto top_right_id = result_ids_h(3);
     REQUIRE(out_of_bounds_dim ==
-            GridPointSearch2D::Results::Dimensionality::VERTEX);
+            PointSearch::Results::Dimensionality::VERTEX);
     REQUIRE(-1 * out_of_bounds_id == top_right_id);
-    REQUIRE(pcms::GetOwningElementId(mesh, mesh.dim(), static_cast<int>(out_of_bounds_dim), -out_of_bounds_id) >= 0);
+    REQUIRE(search->GetOwningElementId(results, 2) >= 0);
 
     out_of_bounds_dim = result_dims_h(4);
     out_of_bounds_id = result_ids_h(4);
     auto bot_left_id = result_ids_h(0);
     REQUIRE(out_of_bounds_dim ==
-            GridPointSearch2D::Results::Dimensionality::VERTEX);
+            PointSearch::Results::Dimensionality::VERTEX);
     REQUIRE(-1 * out_of_bounds_id == bot_left_id);
-    REQUIRE(pcms::GetOwningElementId(mesh, mesh.dim(), static_cast<int>(out_of_bounds_dim), -out_of_bounds_id) >= 0);
+    REQUIRE(search->GetOwningElementId(results, 4) >= 0);
 
-	out_of_bounds_dim = result_dims_h(5);
+  out_of_bounds_dim = result_dims_h(5);
     out_of_bounds_id = result_ids_h(5);
     REQUIRE(out_of_bounds_dim ==
-            GridPointSearch2D::Results::Dimensionality::EDGE);
+            PointSearch::Results::Dimensionality::EDGE);
     REQUIRE(out_of_bounds_id == -219);
-    REQUIRE(pcms::GetOwningElementId(mesh, mesh.dim(), static_cast<int>(out_of_bounds_dim), -out_of_bounds_id) >= 0);
+    REQUIRE(search->GetOwningElementId(results, 5) >= 0);
 
     out_of_bounds_dim = result_dims_h(6);
     out_of_bounds_id = result_ids_h(6);
     REQUIRE(out_of_bounds_dim ==
-            GridPointSearch2D::Results::Dimensionality::EDGE);
+            PointSearch::Results::Dimensionality::EDGE);
     REQUIRE(-1 * out_of_bounds_id == bot_left_id);
-    REQUIRE(pcms::GetOwningElementId(mesh, mesh.dim(), static_cast<int>(out_of_bounds_dim), -out_of_bounds_id) >= 0);
+    REQUIRE(search->GetOwningElementId(results, 6) >= 0);
   }
   SECTION("point on extension of an edge")
   {
@@ -285,8 +286,8 @@ TEST_CASE("uniform grid search 2D")
     ext_h(0, 0) = 1.5;
     ext_h(0, 1) = 0.0;
     Kokkos::deep_copy(ext_points, ext_h);
-    auto ext_results = search.apply(pcms::CoordinateView(pcms::CoordinateSystem::Cartesian, 
-		pcms::MakeConstRank2View(ext_points)));
+    auto ext_results = search->apply(pcms::CoordinateView(pcms::CoordinateSystem::Cartesian, 
+    pcms::MakeConstRank2View(ext_points)));
 
     auto result_dims_h = Kokkos::create_mirror_view(ext_results.dimensionalities);
     Kokkos::deep_copy(result_dims_h, ext_results.dimensionalities);
@@ -297,9 +298,9 @@ TEST_CASE("uniform grid search 2D")
     // Dimensionality must be VERTEX — the nearest entity is the
     // rightmost bottom vertex (1.0, 0).
     REQUIRE(result_dims_h(0) ==
-            GridPointSearch2D::Results::Dimensionality::VERTEX);
+            PointSearch::Results::Dimensionality::VERTEX);
     // Owning element should still resolve to a valid face
-    REQUIRE(pcms::GetOwningElementId(mesh, mesh.dim(), 0, -result_ids_h(0)) >= 0);
+    REQUIRE(search->GetOwningElementId(results, 0) >= 0);
   }
 }
 TEST_CASE("uniform grid search 3D")
@@ -320,126 +321,124 @@ TEST_CASE("uniform grid search 3D")
   GridPointSearch3D search{mesh, 5, 5, 5, tolerances};
 
   auto check_res = [] (auto const& results, int dim)
-	{
-		auto dims = Kokkos::create_mirror_view(results.dimensionalities);
-		auto ids = Kokkos::create_mirror_view(results.element_ids);
-		Kokkos::deep_copy(dims, results.dimensionalities);
-		Kokkos::deep_copy(ids, results.element_ids);
-		for (int i = 0; i < dims.size(); i++)
-		{
-			CHECK(dims(i) == (pcms::PointSearch::Results::Dimensionality)dim);
-			CHECK(ids(i) == i);
-			// CHECK_THAT(results(i).parametric_coords,
-			// 	Catch::Matchers::Contains(Catch::Matchers::WithinAbs(1.0, 10e-7)));
-		}
-	};
-//   SECTION ("Vertex intersection") {
-// 		Kokkos::View<pcms::Real**> coords("vertex coordinates", mesh.nverts(), 3);
-// 		auto coords_h = Kokkos::create_mirror_view(coords);
-// 		auto meshcoords = Omega_h::HostRead(mesh.coords());
-// 		for (int i = 0; i < mesh.nverts(); i++)
-// 		{
-// 			coords_h(i, 0) = meshcoords[i*3];
-// 			coords_h(i, 1) = meshcoords[i*3 + 1];
-// 			coords_h(i, 2) = meshcoords[i*3 + 2];
-// 		}
-// 		Kokkos::deep_copy(coords, coords_h);
-// 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> vert_cv(
-// 			pcms::CoordinateSystem::Cartesian,
-// 			pcms::MakeConstRank2View(coords));
-// 		pcms::PointSearch::Results results = search.apply(vert_cv);
-		
-// 		check_res(results, 0);
-// 	}
-	// SECTION ("Edge intersection") {
-	// 	Kokkos::View<pcms::Real**> coords("intersection coords", mesh.nedges(), 3);
-	// 	auto edge2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::EDGE, Omega_h::VERT).ab2b);
-	// 	auto meshcoords = Omega_h::HostRead(mesh.coords());
-	// 	auto coords_h = Kokkos::create_mirror_view(coords);
+  {
+    auto dims = Kokkos::create_mirror_view(results.dimensionalities);
+    auto ids = Kokkos::create_mirror_view(results.element_ids);
+    Kokkos::deep_copy(dims, results.dimensionalities);
+    Kokkos::deep_copy(ids, results.element_ids);
+    for (int i = 0; i < dims.size(); i++)
+    {
+      CHECK(dims(i) == (pcms::PointSearch::Results::Dimensionality)dim);
+      CHECK(ids(i) == i);
+    }
+  };
+  SECTION ("Vertex intersection") {
+    Kokkos::View<pcms::Real**> coords("vertex coordinates", mesh.nverts(), 3);
+    auto coords_h = Kokkos::create_mirror_view(coords);
+    auto meshcoords = Omega_h::HostRead(mesh.coords());
+    for (int i = 0; i < mesh.nverts(); i++)
+    {
+      coords_h(i, 0) = meshcoords[i*3];
+      coords_h(i, 1) = meshcoords[i*3 + 1];
+      coords_h(i, 2) = meshcoords[i*3 + 2];
+    }
+    Kokkos::deep_copy(coords, coords_h);
+    pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> vert_cv(
+      pcms::CoordinateSystem::Cartesian,
+      pcms::MakeConstRank2View(coords));
+    pcms::PointSearch::Results results = search.apply(vert_cv);
+    
+    check_res(results, 0);
+  }
+  SECTION ("Edge intersection") {
+    Kokkos::View<pcms::Real**> coords("intersection coords", mesh.nedges(), 3);
+    auto edge2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::EDGE, Omega_h::VERT).ab2b);
+    auto meshcoords = Omega_h::HostRead(mesh.coords());
+    auto coords_h = Kokkos::create_mirror_view(coords);
 
-	// 	for (int i = 0; i < mesh.nedges(); i++)
-	// 	{
-	// 		Omega_h::Vector<3> v0{
-	// 			meshcoords[edge2vert[2*i]*3], meshcoords[edge2vert[2*i]*3 + 1], meshcoords[edge2vert[2*i]*3 + 2]
-	// 		};
-	// 		Omega_h::Vector<3> v1{
-	// 			meshcoords[edge2vert[2*i + 1]*3], meshcoords[edge2vert[2*i + 1]*3 + 1], meshcoords[edge2vert[2*i + 1]*3 + 2]
-	// 		};
-	// 		Omega_h::Vector<3> midpoint = (v0 + v1)/2.;
-	// 		coords_h(i, 0) = midpoint[0];
-	// 		coords_h(i, 1) = midpoint[1];
-	// 		coords_h(i, 2) = midpoint[2];
-	// 	}
+    for (int i = 0; i < mesh.nedges(); i++)
+    {
+      Omega_h::Vector<3> v0{
+        meshcoords[edge2vert[2*i]*3], meshcoords[edge2vert[2*i]*3 + 1], meshcoords[edge2vert[2*i]*3 + 2]
+      };
+      Omega_h::Vector<3> v1{
+        meshcoords[edge2vert[2*i + 1]*3], meshcoords[edge2vert[2*i + 1]*3 + 1], meshcoords[edge2vert[2*i + 1]*3 + 2]
+      };
+      Omega_h::Vector<3> midpoint = (v0 + v1)/2.;
+      coords_h(i, 0) = midpoint[0];
+      coords_h(i, 1) = midpoint[1];
+      coords_h(i, 2) = midpoint[2];
+    }
 
-	// 	Kokkos::deep_copy(coords, coords_h);
+    Kokkos::deep_copy(coords, coords_h);
 
-	// 	pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> edge_cv(
-	// 		pcms::CoordinateSystem::Cartesian,
-	// 		pcms::MakeConstRank2View(coords));
-	// 	pcms::PointSearch::Results results = search.apply(edge_cv);
-	// 	check_res(results, 1);
-	// }
-	SECTION ("Face intersection") {
-		Kokkos::View<pcms::Real**> coords("intersection coords", mesh.nfaces(), 3);
-		auto face2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::FACE, Omega_h::VERT).ab2b);
-		auto meshcoords = Omega_h::HostRead(mesh.coords());
-		auto coords_h = Kokkos::create_mirror_view(coords);
+    pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> edge_cv(
+      pcms::CoordinateSystem::Cartesian,
+      pcms::MakeConstRank2View(coords));
+    pcms::PointSearch::Results results = search.apply(edge_cv);
+    check_res(results, 1);
+  }
+  SECTION ("Face intersection") {
+    Kokkos::View<pcms::Real**> coords("intersection coords", mesh.nfaces(), 3);
+    auto face2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::FACE, Omega_h::VERT).ab2b);
+    auto meshcoords = Omega_h::HostRead(mesh.coords());
+    auto coords_h = Kokkos::create_mirror_view(coords);
 
-		for (int i = 0; i < mesh.nfaces(); i++)
-		{
-			Omega_h::Vector<3> v0{
-				meshcoords[face2vert[3*i]*3], meshcoords[face2vert[3*i]*3 + 1], meshcoords[face2vert[3*i]*3 + 2]
-			};
-			Omega_h::Vector<3> v1{
-				meshcoords[face2vert[3*i + 1]*3], meshcoords[face2vert[3*i + 1]*3 + 1], meshcoords[face2vert[3*i + 1]*3 + 2]
-			};
-			Omega_h::Vector<3> v2{
-				meshcoords[face2vert[3*i + 2]*3], meshcoords[face2vert[3*i + 2]*3 + 1], meshcoords[face2vert[3*i + 2]*3 + 2]
-			};
-			Omega_h::Vector<3> midpoint = (v0 + v1 + v2)/3.;
-			coords_h(i, 0) = midpoint[0];
-			coords_h(i, 1) = midpoint[1];
-			coords_h(i, 2) = midpoint[2];
-		}
-		Kokkos::deep_copy(coords, coords_h);
+    for (int i = 0; i < mesh.nfaces(); i++)
+    {
+      Omega_h::Vector<3> v0{
+        meshcoords[face2vert[3*i]*3], meshcoords[face2vert[3*i]*3 + 1], meshcoords[face2vert[3*i]*3 + 2]
+      };
+      Omega_h::Vector<3> v1{
+        meshcoords[face2vert[3*i + 1]*3], meshcoords[face2vert[3*i + 1]*3 + 1], meshcoords[face2vert[3*i + 1]*3 + 2]
+      };
+      Omega_h::Vector<3> v2{
+        meshcoords[face2vert[3*i + 2]*3], meshcoords[face2vert[3*i + 2]*3 + 1], meshcoords[face2vert[3*i + 2]*3 + 2]
+      };
+      Omega_h::Vector<3> midpoint = (v0 + v1 + v2)/3.;
+      coords_h(i, 0) = midpoint[0];
+      coords_h(i, 1) = midpoint[1];
+      coords_h(i, 2) = midpoint[2];
+    }
+    Kokkos::deep_copy(coords, coords_h);
 
-		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> face_cv(
-			pcms::CoordinateSystem::Cartesian,
-			pcms::MakeConstRank2View(coords));
-		pcms::GridPointSearch3D::Results results = search.apply(face_cv);
-		check_res(results, 2);
-	}
-//   SECTION ("Region intersection") {
-// 		Kokkos::View<pcms::Real**> coords("intersection coords", mesh.nelems(), 3);
-//     auto region2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::REGION, Omega_h::VERT).ab2b);
-// 		auto meshcoords = Omega_h::HostRead(mesh.coords());
-// 		auto coords_h = Kokkos::create_mirror_view(coords);
+    pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> face_cv(
+      pcms::CoordinateSystem::Cartesian,
+      pcms::MakeConstRank2View(coords));
+    pcms::GridPointSearch3D::Results results = search.apply(face_cv);
+    check_res(results, 2);
+  }
+  SECTION ("Region intersection") {
+    Kokkos::View<pcms::Real**> coords("intersection coords", mesh.nelems(), 3);
+    auto region2vert = Omega_h::HostRead(mesh.get_adj(Omega_h::REGION, Omega_h::VERT).ab2b);
+    auto meshcoords = Omega_h::HostRead(mesh.coords());
+    auto coords_h = Kokkos::create_mirror_view(coords);
 
-// 		for (unsigned i = 0; i < mesh.nelems(); i++)
-// 		{
-//       Omega_h::Vector<3> v0{
-// 				meshcoords[region2vert[4*i]*3], meshcoords[region2vert[4*i]*3 + 1], meshcoords[region2vert[4*i]*3 + 2]
-// 			};
-// 			Omega_h::Vector<3> v1{
-// 				meshcoords[region2vert[4*i + 1]*3], meshcoords[region2vert[4*i + 1]*3 + 1], meshcoords[region2vert[4*i + 1]*3 + 2]
-// 			};
-// 			Omega_h::Vector<3> v2{
-// 				meshcoords[region2vert[4*i + 2]*3], meshcoords[region2vert[4*i + 2]*3 + 1], meshcoords[region2vert[4*i + 2]*3 + 2]
-// 			};
-// 			Omega_h::Vector<3> v3{
-// 				meshcoords[region2vert[4*i + 3]*3], meshcoords[region2vert[4*i + 3]*3 + 1], meshcoords[region2vert[4*i + 3]*3 + 2]
-// 			};
-// 			Omega_h::Vector<3> midpoint = (v0 + v1 + v2 + v3)/4.;
-// 			coords_h(i, 0) = midpoint[0];
-// 			coords_h(i, 1) = midpoint[1];
-// 			coords_h(i, 2) = midpoint[2];
-// 		}
-// 		Kokkos::deep_copy(coords, coords_h);
+    for (unsigned i = 0; i < mesh.nelems(); i++)
+    {
+      Omega_h::Vector<3> v0{
+        meshcoords[region2vert[4*i]*3], meshcoords[region2vert[4*i]*3 + 1], meshcoords[region2vert[4*i]*3 + 2]
+      };
+      Omega_h::Vector<3> v1{
+        meshcoords[region2vert[4*i + 1]*3], meshcoords[region2vert[4*i + 1]*3 + 1], meshcoords[region2vert[4*i + 1]*3 + 2]
+      };
+      Omega_h::Vector<3> v2{
+        meshcoords[region2vert[4*i + 2]*3], meshcoords[region2vert[4*i + 2]*3 + 1], meshcoords[region2vert[4*i + 2]*3 + 2]
+      };
+      Omega_h::Vector<3> v3{
+        meshcoords[region2vert[4*i + 3]*3], meshcoords[region2vert[4*i + 3]*3 + 1], meshcoords[region2vert[4*i + 3]*3 + 2]
+      };
+      Omega_h::Vector<3> midpoint = (v0 + v1 + v2 + v3)/4.;
+      coords_h(i, 0) = midpoint[0];
+      coords_h(i, 1) = midpoint[1];
+      coords_h(i, 2) = midpoint[2];
+    }
+    Kokkos::deep_copy(coords, coords_h);
 
-// 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> region_cv(
-// 			pcms::CoordinateSystem::Cartesian,
-// 			pcms::MakeConstRank2View(coords));
-// 		pcms::PointSearch::Results results = search.apply(region_cv);
-// 		check_res(results, 3);
-	// }
+    pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> region_cv(
+      pcms::CoordinateSystem::Cartesian,
+      pcms::MakeConstRank2View(coords));
+    pcms::PointSearch::Results results = search.apply(region_cv);
+    check_res(results, 3);
+  }
 }

--- a/test/test_tree_localization.cpp
+++ b/test/test_tree_localization.cpp
@@ -12,7 +12,7 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 	// Setup for 1x1 grid test cases
 	auto lib = Omega_h::Library{};
 	auto world = lib.world();
-	Omega_h::Mesh mesh_1x1 = Omega_h::build_box(world, OMEGA_H_SIMPLEX, 1, 1, 1, 100, 100, 0, false);
+	Omega_h::Mesh mesh_1x1 = Omega_h::build_box(world, OMEGA_H_SIMPLEX, 1, 1, 1, 10, 10, 0, false);
 	REQUIRE(mesh_1x1.dim() == 2);
 	Omega_h::ExecSpace execs;
 	
@@ -135,7 +135,7 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 	// Setup for 1x1x1 grid test cases
 	auto lib = Omega_h::Library{};
 	auto world = lib.world();
-	Omega_h::Mesh mesh_1x1 = Omega_h::build_box(world, OMEGA_H_SIMPLEX, 1, 1, 1, 20, 20, 20, false);
+	Omega_h::Mesh mesh_1x1 = Omega_h::build_box(world, OMEGA_H_SIMPLEX, 1, 1, 1, 5, 5, 5, false);
 	REQUIRE(mesh_1x1.dim() == 3);
 	Omega_h::ExecSpace execs;
 	

--- a/test/test_tree_localization.cpp
+++ b/test/test_tree_localization.cpp
@@ -145,3 +145,178 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 		check_outside(results);
 	}
 }
+
+TEST_CASE ("Test 1x1x1 3D grid point classification") {
+	// Setup for 1x1x1 grid test cases
+	auto lib = Omega_h::Library{};
+	auto world = lib.world();
+	Omega_h::Mesh mesh_1x1 = Omega_h::build_box(world, OMEGA_H_SIMPLEX, 1, 1, 1, 1, 1, 1, false);
+	REQUIRE(mesh_1x1.dim() == 3);
+	Omega_h::ExecSpace execs;
+	
+	pcms::TreePointSearch3D tree_search(mesh_1x1);
+	// End setup for 1x1 grid test cases
+
+	auto check_verts = KOKKOS_LAMBDA (auto const& results)
+	{
+		for (int i = 0; i < mesh_1x1.nverts(); i++)
+		{
+			CHECK(results(i).dimensionality == pcms::TreePointSearch3D::Dim_t::VERTEX);
+			CHECK(results(i).element_id == i);
+			CHECK_THAT(results(i).parametric_coords,
+				Catch::Matchers::Contains(Catch::Matchers::WithinAbs(1.0, 10e-7)));
+		}
+	};
+
+	auto check_edges = KOKKOS_LAMBDA (auto const& results)
+	{
+		for (int i = 0; i < mesh_1x1.nedges(); i++)
+		{
+			CHECK(results(i).dimensionality == pcms::TreePointSearch3D::Dim_t::EDGE);
+			CHECK(results(i).element_id == i);
+		}
+	};
+
+	auto check_faces = KOKKOS_LAMBDA (auto const& results)
+	{
+		for (int i = 0; i < results.size(); i++)
+		{
+			CHECK(results(i).dimensionality == pcms::TreePointSearch3D::Dim_t::FACE);
+			CHECK(results(i).element_id == i);
+		}
+	};
+
+	auto check_regions = KOKKOS_LAMBDA (auto const& results)
+	{
+		for (int i = 0; i < results.size(); i++)
+		{
+			CHECK(results(i).dimensionality == pcms::TreePointSearch3D::Dim_t::REGION);
+			CHECK(results(i).element_id == i);
+		}
+	};
+
+	auto check_outside = KOKKOS_LAMBDA (auto const& results)
+	{
+		for (int i = 0; i < results.size(); i++)
+		{
+			CHECK(results(i).dimensionality == pcms::TreePointSearch3D::Dim_t::REGION);
+			CHECK(results(i).element_id == -1);
+		}
+	};
+
+	SECTION ("Vertex intersection") {
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> vert_cv(
+			pcms::CoordinateSystem::Cartesian,
+			pcms::MakeConstRank2View(mesh_1x1.coords(), 3));
+		Kokkos::View<pcms::TreePointSearch3D::Result_t*> results 
+			= tree_search.apply(vert_cv);
+		check_verts(results);
+	}
+	SECTION ("Edge intersection") {
+		Omega_h::Write<pcms::Real> coords(mesh_1x1.nedges()*3);
+		auto edge2vert = mesh_1x1.get_adj(Omega_h::EDGE, Omega_h::VERT).ab2b;
+		auto meshcoords = mesh_1x1.coords();
+		for (int i = 0; i < mesh_1x1.nedges(); i++)
+		{
+			Omega_h::Vector<3> v0{
+				meshcoords[edge2vert[2*i]*3], meshcoords[edge2vert[2*i]*3 + 1], meshcoords[edge2vert[2*i]*3 + 2]
+			};
+			Omega_h::Vector<3> v1{
+				meshcoords[edge2vert[2*i + 1]*3], meshcoords[edge2vert[2*i + 1]*3 + 1], meshcoords[edge2vert[2*i + 1]*3 + 2]
+			};
+			Omega_h::Vector<3> midpoint = (v0 + v1)/2.;
+			coords[i*3] = midpoint[0];
+			coords[i*3 + 1] = midpoint[1];
+			coords[i*3 + 2] = midpoint[2];
+		}
+
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> edge_cv(
+			pcms::CoordinateSystem::Cartesian,
+			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 3));
+		Kokkos::View<pcms::TreePointSearch3D::Result_t*> results 
+			= tree_search.apply(edge_cv);
+		check_edges(results);
+	}
+	SECTION ("Face intersection") {
+		Omega_h::Write<pcms::Real> coords(mesh_1x1.nfaces()*3);
+		auto face2vert = mesh_1x1.get_adj(Omega_h::FACE, Omega_h::VERT).ab2b;
+		auto meshcoords = mesh_1x1.coords();
+
+		for (int i = 0; i < mesh_1x1.nfaces(); i++)
+		{
+			Omega_h::Vector<3> v0{
+				meshcoords[face2vert[3*i]*3], meshcoords[face2vert[3*i]*3 + 1], meshcoords[face2vert[3*i]*3 + 2]
+			};
+			Omega_h::Vector<3> v1{
+				meshcoords[face2vert[3*i + 1]*3], meshcoords[face2vert[3*i + 1]*3 + 1], meshcoords[face2vert[3*i + 1]*3 + 2]
+			};
+			Omega_h::Vector<3> v2{
+				meshcoords[face2vert[3*i + 2]*3], meshcoords[face2vert[3*i + 2]*3 + 1], meshcoords[face2vert[3*i + 2]*3 + 2]
+			};
+			Omega_h::Vector<3> midpoint = (v0 + v1 + v2)/3.;
+			coords[i*3] = midpoint[0];
+			coords[i*3 + 1] = midpoint[1];
+			coords[i*3 + 2] = midpoint[2];
+		}
+
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> face_cv(
+			pcms::CoordinateSystem::Cartesian,
+			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 3));
+		Kokkos::View<pcms::TreePointSearch3D::Result_t*> results 
+			= tree_search.apply(face_cv);
+		check_faces(results);
+	}
+	SECTION ("Region intersection") {
+		Omega_h::Write<pcms::Real> coords(mesh_1x1.nelems()*3);
+		auto region2vert = mesh_1x1.get_adj(Omega_h::REGION, Omega_h::VERT).ab2b;
+		auto meshcoords = mesh_1x1.coords();
+
+		for (int i = 0; i < mesh_1x1.nelems(); i++)
+		{
+			Omega_h::Vector<3> v0{
+				meshcoords[region2vert[4*i]*3], meshcoords[region2vert[4*i]*3 + 1], meshcoords[region2vert[4*i]*3 + 2]
+			};
+			Omega_h::Vector<3> v1{
+				meshcoords[region2vert[4*i + 1]*3], meshcoords[region2vert[4*i + 1]*3 + 1], meshcoords[region2vert[4*i + 1]*3 + 2]
+			};
+			Omega_h::Vector<3> v2{
+				meshcoords[region2vert[4*i + 2]*3], meshcoords[region2vert[4*i + 2]*3 + 1], meshcoords[region2vert[4*i + 2]*3 + 2]
+			};
+			Omega_h::Vector<3> v3{
+				meshcoords[region2vert[4*i + 3]*3], meshcoords[region2vert[4*i + 3]*3 + 1], meshcoords[region2vert[4*i + 3]*3 + 2]
+			};
+			Omega_h::Vector<3> midpoint = (v0 + v1 + v2 + v3)/4.;
+			coords[i*3] = midpoint[0];
+			coords[i*3 + 1] = midpoint[1];
+			coords[i*3 + 2] = midpoint[2];
+		}
+
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> region_cv(
+			pcms::CoordinateSystem::Cartesian,
+			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 3));
+		Kokkos::View<pcms::TreePointSearch3D::Result_t*> results 
+			= tree_search.apply(region_cv);
+		check_regions(results);
+	}
+
+	SECTION ("Region intersection") {
+		Omega_h::Write<pcms::Real> coords
+		{
+			-0.5, -0.5, -0.5,
+			-0.5, -0.5, 1.5,
+			-0.5, 1.5, -0.5,
+			-0.5, 1.5, 1.5,
+			1.5, -0.5, -0.5,
+			1.5, -0.5, 1.5,
+			1.5, 1.5, -0.5,
+			1.5, 1.5, 1.5
+		};
+
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> outside_cv(
+			pcms::CoordinateSystem::Cartesian,
+			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 3));
+		Kokkos::View<pcms::TreePointSearch3D::Result_t*> results 
+			= tree_search.apply(outside_cv);
+		check_outside(results);
+	}
+}

--- a/test/test_tree_localization.cpp
+++ b/test/test_tree_localization.cpp
@@ -19,9 +19,9 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 	pcms::TreePointSearch tree_search(mesh_1x1);
 	// End setup for 1x1 grid test cases
 
-	auto check_verts = KOKKOS_LAMBDA (auto const& results)
+	auto check_verts = [] (auto const& results)
 	{
-		for (int i = 0; i < mesh_1x1.nverts(); i++)
+		for (int i = 0; i < results.size(); i++)
 		{
 			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::VERTEX);
 			CHECK(results(i).element_id == i);
@@ -30,16 +30,16 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 		}
 	};
 
-	auto check_edges = KOKKOS_LAMBDA (auto const& results)
+	auto check_edges = [] (auto const& results)
 	{
-		for (int i = 0; i < mesh_1x1.nedges(); i++)
+		for (int i = 0; i < results.size(); i++)
 		{
 			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::EDGE);
 			CHECK(results(i).element_id == i);
 		}
 	};
 
-	auto check_faces = KOKKOS_LAMBDA (auto const& results)
+	auto check_faces = [] (auto const& results)
 	{
 		for (int i = 0; i < results.size(); i++)
 		{
@@ -48,7 +48,7 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 		}
 	};
 
-	auto check_outside = KOKKOS_LAMBDA (auto const& results)
+	auto check_outside = [] (auto const& results)
 	{
 		for (int i = 0; i < results.size(); i++)
 		{
@@ -58,17 +58,29 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 	};
 
 	SECTION ("Vertex intersection") {
-		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> vert_cv(
+		Kokkos::View<pcms::Real**, pcms::TreePointSearch::MemorySpace> coords("vertex coordinates", mesh_1x1.nverts(), 2);
+		auto coords_h = Kokkos::create_mirror_view(coords);
+		auto meshcoords = Omega_h::HostRead(mesh_1x1.coords());
+		for (int i = 0; i < mesh_1x1.nverts(); i++)
+		{
+			coords_h(i,0) = meshcoords[i*2];
+			coords_h(i,1) = meshcoords[i*2 + 1];
+		}
+		Kokkos::deep_copy(execs, coords, coords_h);
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> vert_cv(
 			pcms::CoordinateSystem::Cartesian,
-			pcms::MakeConstRank2View(mesh_1x1.coords(), 2));
+			pcms::MakeConstRank2View(coords));
 		Kokkos::View<pcms::TreePointSearch::Result*> results 
 			= tree_search.apply(vert_cv);
-		check_verts(results);
+		auto results_h = Kokkos::create_mirror_view(results);
+		Kokkos::deep_copy(execs, results_h, results);
+		check_verts(results_h);
 	}
 	SECTION ("Edge intersection") {
-		Omega_h::Write<pcms::Real> coords(mesh_1x1.nedges()*2);
-		auto edge2vert = mesh_1x1.get_adj(Omega_h::EDGE, Omega_h::VERT).ab2b;
-		auto meshcoords = mesh_1x1.coords();
+		Kokkos::View<pcms::Real**, pcms::TreePointSearch::MemorySpace> coords("edge coordinates", mesh_1x1.nedges(), 2);
+		auto coords_h = Kokkos::create_mirror_view(coords);
+		auto edge2vert = Omega_h::HostRead(mesh_1x1.get_adj(Omega_h::EDGE, Omega_h::VERT).ab2b);
+		auto meshcoords = Omega_h::HostRead(mesh_1x1.coords());
 		for (int i = 0; i < mesh_1x1.nedges(); i++)
 		{
 			Omega_h::Vector<2> v0{
@@ -78,22 +90,25 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 				meshcoords[edge2vert[2*i + 1]*2], meshcoords[edge2vert[2*i + 1]*2 + 1]
 			};
 			Omega_h::Vector<2> midpoint = (v0 + v1)/2.;
-			coords[i*2] = midpoint[0];
-			coords[i*2 + 1] = midpoint[1];
+			coords_h(i,0) = midpoint[0];
+			coords_h(i,1) = midpoint[1];
 		}
+		Kokkos::deep_copy(execs, coords, coords_h);
 
-		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> edge_cv(
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> edge_cv(
 			pcms::CoordinateSystem::Cartesian,
-			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 2));
+			pcms::MakeConstRank2View(coords));
 		Kokkos::View<pcms::TreePointSearch::Result*> results 
 			= tree_search.apply(edge_cv);
-		check_edges(results);
+		auto results_h = Kokkos::create_mirror_view(results);
+		Kokkos::deep_copy(execs, results_h, results);
+		check_edges(results_h);
 	}
 	SECTION ("Face intersection") {
-		Omega_h::Write<pcms::Real> coords(mesh_1x1.nfaces()*2);
-		auto face2vert = mesh_1x1.get_adj(Omega_h::FACE, Omega_h::VERT).ab2b;
-		auto meshcoords = mesh_1x1.coords();
-
+		Kokkos::View<pcms::Real**, pcms::TreePointSearch::MemorySpace> coords("face coordinates", mesh_1x1.nfaces(), 2);
+		auto face2vert = Omega_h::HostRead(mesh_1x1.get_adj(Omega_h::FACE, Omega_h::VERT).ab2b);
+		auto meshcoords = Omega_h::HostRead(mesh_1x1.coords());
+		auto coords_h = Kokkos::create_mirror_view(coords);
 		for (int i = 0; i < mesh_1x1.nfaces(); i++)
 		{
 			Omega_h::Vector<2> v0{
@@ -106,44 +121,49 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 				meshcoords[face2vert[3*i + 2]*2], meshcoords[face2vert[3*i + 2]*2 + 1]
 			};
 			Omega_h::Vector<2> midpoint = (v0 + v1 + v2)/3.;
-			coords[i*2] = midpoint[0];
-			coords[i*2 + 1] = midpoint[1];
+			coords_h(i,0) = midpoint[0];
+			coords_h(i,1) = midpoint[1];
 		}
+		Kokkos::deep_copy(execs, coords, coords_h);
 
-		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> face_cv(
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> face_cv(
 			pcms::CoordinateSystem::Cartesian,
-			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 2));
+			pcms::MakeConstRank2View(coords));
 		Kokkos::View<pcms::TreePointSearch::Result*> results 
 			= tree_search.apply(face_cv);
-		check_faces(results);
+		auto results_h = Kokkos::create_mirror_view(results);
+		Kokkos::deep_copy(execs, results_h, results);
+		check_faces(results_h);
 	}
-	SECTION("Outside Mesh") {
-		Omega_h::Write<pcms::Real> coords
-		{
-			-0.5, -0.5,
-			-0.5, 0.0,
-			-0.5, 0.5,
-			-0.5, 1.0,
-			-0.5, 1.5,
-			0.0, -0.5,
-			0.0, 1.5,
-			0.5, -0.5,
-			0.5, 1.5,
-			1.0, -0.5,
-			1.0, 1.5,
-			1.5, -0.5,
-			1.5, 0.0,
-			1.5, 0.5,
-			1.5, 1.0,
-			1.5, 1.5
-		};
-		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> outside_cv(
-			pcms::CoordinateSystem::Cartesian,
-			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 2));
-		Kokkos::View<pcms::TreePointSearch::Result*> results 
-			= tree_search.apply(outside_cv);
-		check_outside(results);
-	}
+	// SECTION("Outside Mesh") {
+	// 	Omega_h::Write<pcms::Real> coords
+	// 	{
+	// 		-0.5, -0.5,
+	// 		-0.5, 0.0,
+	// 		-0.5, 0.5,
+	// 		-0.5, 1.0,
+	// 		-0.5, 1.5,
+	// 		0.0, -0.5,
+	// 		0.0, 1.5,
+	// 		0.5, -0.5,
+	// 		0.5, 1.5,
+	// 		1.0, -0.5,
+	// 		1.0, 1.5,
+	// 		1.5, -0.5,
+	// 		1.5, 0.0,
+	// 		1.5, 0.5,
+	// 		1.5, 1.0,
+	// 		1.5, 1.5
+	// 	};
+	// 	pcms::CoordinateView<Omega_h::ExecSpace::memory_space> outside_cv(
+	// 		pcms::CoordinateSystem::Cartesian,
+	// 		pcms::MakeConstRank2View(coords));
+	// 	Kokkos::View<pcms::TreePointSearch::Result*> results 
+	// 		= tree_search.apply(outside_cv);
+// auto results_h = Kokkos::create_mirror_view(results);
+// Kokkos::deep_copy(execs, results_h, results);
+	// 	check_outside(results_h);
+	// }
 }
 
 TEST_CASE ("Test 1x1x1 3D grid point classification") {
@@ -157,25 +177,25 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 	pcms::TreePointSearch tree_search(mesh_1x1);
 	// End setup for 1x1 grid test cases
 
-	auto check_verts = KOKKOS_LAMBDA (auto const& results)
+	auto check_verts = [] (auto const& results)
 	{
-		for (int i = 0; i < mesh_1x1.nverts(); i++)
+		for (int i = 0; i < results.size(); i++)
 		{
 			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::VERTEX);
 			CHECK(results(i).element_id == i);
 		}
 	};
 
-	auto check_edges = KOKKOS_LAMBDA (auto const& results)
+	auto check_edges = [] (auto const& results)
 	{
-		for (int i = 0; i < mesh_1x1.nedges(); i++)
+		for (int i = 0; i < results.size(); i++)
 		{
 			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::EDGE);
 			CHECK(results(i).element_id == i);
 		}
 	};
 
-	auto check_faces = KOKKOS_LAMBDA (auto const& results)
+	auto check_faces = [] (auto const& results)
 	{
 		for (int i = 0; i < results.size(); i++)
 		{
@@ -184,7 +204,7 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 		}
 	};
 
-	auto check_regions = KOKKOS_LAMBDA (auto const& results)
+	auto check_regions = [] (auto const& results)
 	{
 		for (int i = 0; i < results.size(); i++)
 		{
@@ -193,7 +213,7 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 		}
 	};
 
-	auto check_outside = KOKKOS_LAMBDA (auto const& results)
+	auto check_outside = [] (auto const& results)
 	{
 		for (int i = 0; i < results.size(); i++)
 		{
@@ -203,17 +223,32 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 	};
 
 	SECTION ("Vertex intersection") {
-		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> vert_cv(
+		Kokkos::View<pcms::Real**, pcms::TreePointSearch::MemorySpace> coords("vertex coordinates", mesh_1x1.nverts(), 3);
+		auto coords_h = Kokkos::create_mirror_view(coords);
+		auto meshcoords = Omega_h::HostRead(mesh_1x1.coords());
+		for (int i = 0; i < mesh_1x1.nverts(); i++)
+		{
+			coords_h(i, 0) = meshcoords[i*3];
+			coords_h(i, 1) = meshcoords[i*3 + 1];
+			coords_h(i, 2) = meshcoords[i*3 + 2];
+		}
+		Kokkos::deep_copy(execs, coords, coords_h);
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> vert_cv(
 			pcms::CoordinateSystem::Cartesian,
-			pcms::MakeConstRank2View(mesh_1x1.coords(), 3));
+			pcms::MakeConstRank2View(coords));
 		Kokkos::View<pcms::TreePointSearch::Result*> results 
 			= tree_search.apply(vert_cv);
-		check_verts(results);
+		auto results_h = Kokkos::create_mirror_view(results);
+		Kokkos::deep_copy(execs, results_h, results);
+		
+		check_verts(results_h);
 	}
 	SECTION ("Edge intersection") {
-		Omega_h::Write<pcms::Real> coords(mesh_1x1.nedges()*3);
-		auto edge2vert = mesh_1x1.get_adj(Omega_h::EDGE, Omega_h::VERT).ab2b;
-		auto meshcoords = mesh_1x1.coords();
+		Kokkos::View<pcms::Real**, pcms::TreePointSearch::MemorySpace> coords("intersection coords", mesh_1x1.nedges(), 3);
+		auto edge2vert = Omega_h::HostRead(mesh_1x1.get_adj(Omega_h::EDGE, Omega_h::VERT).ab2b);
+		auto meshcoords = Omega_h::HostRead(mesh_1x1.coords());
+		auto coords_h = Kokkos::create_mirror_view(coords);
+
 		for (int i = 0; i < mesh_1x1.nedges(); i++)
 		{
 			Omega_h::Vector<3> v0{
@@ -223,22 +258,27 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 				meshcoords[edge2vert[2*i + 1]*3], meshcoords[edge2vert[2*i + 1]*3 + 1], meshcoords[edge2vert[2*i + 1]*3 + 2]
 			};
 			Omega_h::Vector<3> midpoint = (v0 + v1)/2.;
-			coords[i*3] = midpoint[0];
-			coords[i*3 + 1] = midpoint[1];
-			coords[i*3 + 2] = midpoint[2];
+			coords_h(i, 0) = midpoint[0];
+			coords_h(i, 1) = midpoint[1];
+			coords_h(i, 2) = midpoint[2];
 		}
 
-		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> edge_cv(
+		Kokkos::deep_copy(execs, coords, coords_h);
+
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> edge_cv(
 			pcms::CoordinateSystem::Cartesian,
-			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 3));
+			pcms::MakeConstRank2View(coords));
 		Kokkos::View<pcms::TreePointSearch::Result*> results 
 			= tree_search.apply(edge_cv);
-		check_edges(results);
+		auto results_h = Kokkos::create_mirror_view(results);
+		Kokkos::deep_copy(execs, results_h, results);
+		check_edges(results_h);
 	}
 	SECTION ("Face intersection") {
-		Omega_h::Write<pcms::Real> coords(mesh_1x1.nfaces()*3);
-		auto face2vert = mesh_1x1.get_adj(Omega_h::FACE, Omega_h::VERT).ab2b;
-		auto meshcoords = mesh_1x1.coords();
+		Kokkos::View<pcms::Real**, pcms::TreePointSearch::MemorySpace> coords("intersection coords", mesh_1x1.nfaces(), 3);
+		auto face2vert = Omega_h::HostRead(mesh_1x1.get_adj(Omega_h::FACE, Omega_h::VERT).ab2b);
+		auto meshcoords = Omega_h::HostRead(mesh_1x1.coords());
+		auto coords_h = Kokkos::create_mirror_view(coords);
 
 		for (int i = 0; i < mesh_1x1.nfaces(); i++)
 		{
@@ -252,22 +292,26 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 				meshcoords[face2vert[3*i + 2]*3], meshcoords[face2vert[3*i + 2]*3 + 1], meshcoords[face2vert[3*i + 2]*3 + 2]
 			};
 			Omega_h::Vector<3> midpoint = (v0 + v1 + v2)/3.;
-			coords[i*3] = midpoint[0];
-			coords[i*3 + 1] = midpoint[1];
-			coords[i*3 + 2] = midpoint[2];
+			coords_h(i, 0) = midpoint[0];
+			coords_h(i, 1) = midpoint[1];
+			coords_h(i, 2) = midpoint[2];
 		}
+		Kokkos::deep_copy(execs, coords, coords_h);
 
-		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> face_cv(
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> face_cv(
 			pcms::CoordinateSystem::Cartesian,
-			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 3));
+			pcms::MakeConstRank2View(coords));
 		Kokkos::View<pcms::TreePointSearch::Result*> results 
 			= tree_search.apply(face_cv);
-		check_faces(results);
+		auto results_h = Kokkos::create_mirror_view(results);
+		Kokkos::deep_copy(execs, results_h, results);
+		check_faces(results_h);
 	}
 	SECTION ("Region intersection") {
-		Omega_h::Write<pcms::Real> coords(mesh_1x1.nelems()*3);
-		auto region2vert = mesh_1x1.get_adj(Omega_h::REGION, Omega_h::VERT).ab2b;
-		auto meshcoords = mesh_1x1.coords();
+		Kokkos::View<pcms::Real**, pcms::TreePointSearch::MemorySpace> coords("intersection coords", mesh_1x1.nelems(), 3);
+		auto region2vert = Omega_h::HostRead(mesh_1x1.get_adj(Omega_h::REGION, Omega_h::VERT).ab2b);
+		auto meshcoords = Omega_h::HostRead(mesh_1x1.coords());
+		auto coords_h = Kokkos::create_mirror_view(coords);
 
 		for (int i = 0; i < mesh_1x1.nelems(); i++)
 		{
@@ -284,37 +328,42 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 				meshcoords[region2vert[4*i + 3]*3], meshcoords[region2vert[4*i + 3]*3 + 1], meshcoords[region2vert[4*i + 3]*3 + 2]
 			};
 			Omega_h::Vector<3> midpoint = (v0 + v1 + v2 + v3)/4.;
-			coords[i*3] = midpoint[0];
-			coords[i*3 + 1] = midpoint[1];
-			coords[i*3 + 2] = midpoint[2];
+			coords_h(i, 0) = midpoint[0];
+			coords_h(i, 1) = midpoint[1];
+			coords_h(i, 2) = midpoint[2];
 		}
+		Kokkos::deep_copy(execs, coords, coords_h);
 
-		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> region_cv(
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> region_cv(
 			pcms::CoordinateSystem::Cartesian,
-			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 3));
+			pcms::MakeConstRank2View(coords));
 		Kokkos::View<pcms::TreePointSearch::Result*> results 
 			= tree_search.apply(region_cv);
-		check_regions(results);
+		auto results_h = Kokkos::create_mirror_view(results);
+		Kokkos::deep_copy(execs, results_h, results);
+		check_regions(results_h);
 	}
 
-	SECTION ("Region intersection") {
-		Omega_h::Write<pcms::Real> coords
-		{
-			-0.5, -0.5, -0.5,
-			-0.5, -0.5, 1.5,
-			-0.5, 1.5, -0.5,
-			-0.5, 1.5, 1.5,
-			1.5, -0.5, -0.5,
-			1.5, -0.5, 1.5,
-			1.5, 1.5, -0.5,
-			1.5, 1.5, 1.5
-		};
+	// SECTION ("Region intersection") {
+	// 	Kokkos::View<pcms::Real**, pcms::TreePointSearch::MemorySpace> coords
+	// 	{
+	// 		-0.5, -0.5, -0.5,
+	// 		-0.5, -0.5, 1.5,
+	// 		-0.5, 1.5, -0.5,
+	// 		-0.5, 1.5, 1.5,
+	// 		1.5, -0.5, -0.5,
+	// 		1.5, -0.5, 1.5,
+	// 		1.5, 1.5, -0.5,
+	// 		1.5, 1.5, 1.5
+	// 	};
 
-		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> outside_cv(
-			pcms::CoordinateSystem::Cartesian,
-			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 3));
-		Kokkos::View<pcms::TreePointSearch::Result*> results 
-			= tree_search.apply(outside_cv);
-		check_outside(results);
-	}
+	// 	pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> outside_cv(
+	// 		pcms::CoordinateSystem::Cartesian,
+	// 		pcms::MakeConstRank2View(coords));
+	// 	Kokkos::View<pcms::TreePointSearch::Result*> results 
+	// 		= tree_search.apply(outside_cv);
+// auto results_h = Kokkos::create_mirror_view(results);
+// Kokkos::deep_copy(execs, results_h, results);
+	// 	check_outside(results_h);
+	// }
 }

--- a/test/test_tree_localization.cpp
+++ b/test/test_tree_localization.cpp
@@ -39,6 +39,15 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 		}
 	};
 
+	auto check_faces = KOKKOS_LAMBDA (auto const& results)
+	{
+		for (int i = 0; i < results.size(); i++)
+		{
+			CHECK(results(i).dimensionality == pcms::TreePointSearch2D::Dim_t::FACE);
+			CHECK(results(i).element_id == i);
+		}
+	};
+
 	SECTION ("Vertex intersection") {
 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> vert_cv(
 			pcms::CoordinateSystem::Cartesian,
@@ -72,6 +81,31 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 		check_edges(results);
 	}
 	SECTION ("Face intersection") {
-		
+		Omega_h::Write<pcms::Real> coords(mesh_1x1.nfaces()*2);
+		auto face2vert = mesh_1x1.get_adj(Omega_h::FACE, Omega_h::VERT).ab2b;
+		auto meshcoords = mesh_1x1.coords();
+
+		for (int i = 0; i < mesh_1x1.nfaces(); i++)
+		{
+			Omega_h::Vector<2> v0{
+				meshcoords[face2vert[3*i]*2], meshcoords[face2vert[3*i]*2 + 1]
+			};
+			Omega_h::Vector<2> v1{
+				meshcoords[face2vert[3*i + 1]*2], meshcoords[face2vert[3*i + 1]*2 + 1]
+			};
+			Omega_h::Vector<2> v2{
+				meshcoords[face2vert[3*i + 2]*2], meshcoords[face2vert[3*i + 2]*2 + 1]
+			};
+			Omega_h::Vector<2> midpoint = (v0 + v1 + v2)/3.;
+			coords[i*2] = midpoint[0];
+			coords[i*2 + 1] = midpoint[1];
+		}
+
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> face_cv(
+			pcms::CoordinateSystem::Cartesian,
+			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 2));
+		Kokkos::View<pcms::TreePointSearch2D::Result_t*> results 
+			= tree_search.apply(face_cv);
+		check_faces(results);
 	}
 }

--- a/test/test_tree_localization.cpp
+++ b/test/test_tree_localization.cpp
@@ -8,8 +8,8 @@
 
 #include <pcms/localization/point_localization.h>
 
-TEST_CASE ("Test 1x1 2D grid point classification") {
-	// Setup for 1x1 grid test cases
+TEST_CASE ("Test 10x10 2D tree point classification") {
+	// Setup for 10x10 tree test cases
 	auto lib = Omega_h::Library{};
 	auto world = lib.world();
 	Omega_h::Mesh mesh_1x1 = Omega_h::build_box(world, OMEGA_H_SIMPLEX, 1, 1, 1, 10, 10, 0, false);
@@ -17,7 +17,7 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 	Omega_h::ExecSpace execs;
 	
 	pcms::TreePointSearch tree_search(mesh_1x1);
-	// End setup for 1x1 grid test cases
+	// End setup for 10x10 tree test cases
 
 	auto check_res = [] (auto const& results, int dim)
 	{
@@ -131,8 +131,8 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 	// }
 }
 
-TEST_CASE ("Test 1x1x1 3D grid point classification") {
-	// Setup for 1x1x1 grid test cases
+TEST_CASE ("Test 5x5x5 3D tree point classification") {
+	// Setup for 5x5x5 tree test cases
 	auto lib = Omega_h::Library{};
 	auto world = lib.world();
 	Omega_h::Mesh mesh_1x1 = Omega_h::build_box(world, OMEGA_H_SIMPLEX, 1, 1, 1, 5, 5, 5, false);
@@ -140,7 +140,6 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 	Omega_h::ExecSpace execs;
 	
 	pcms::TreePointSearch tree_search(mesh_1x1);
-	// End setup for 1x1 grid test cases
 
 	auto check_res = [] (auto const& results, int dim)
 	{

--- a/test/test_tree_localization.cpp
+++ b/test/test_tree_localization.cpp
@@ -16,17 +16,17 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 	REQUIRE(mesh_1x1.dim() == 2);
 	Omega_h::ExecSpace execs;
 	
-	pcms::TreePointSearch2D tree_search(mesh_1x1);
+	pcms::TreePointSearch tree_search(mesh_1x1);
 	// End setup for 1x1 grid test cases
 
 	auto check_verts = KOKKOS_LAMBDA (auto const& results)
 	{
 		for (int i = 0; i < mesh_1x1.nverts(); i++)
 		{
-			CHECK(results(i).dimensionality == pcms::TreePointSearch2D::Dim_t::VERTEX);
+			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::VERTEX);
 			CHECK(results(i).element_id == i);
-			CHECK_THAT(results(i).parametric_coords,
-				Catch::Matchers::Contains(Catch::Matchers::WithinAbs(1.0, 10e-7)));
+			// CHECK_THAT(results(i).parametric_coords,
+			// 	Catch::Matchers::Contains(Catch::Matchers::WithinAbs(1.0, 10e-7)));
 		}
 	};
 
@@ -34,7 +34,7 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 	{
 		for (int i = 0; i < mesh_1x1.nedges(); i++)
 		{
-			CHECK(results(i).dimensionality == pcms::TreePointSearch2D::Dim_t::EDGE);
+			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::EDGE);
 			CHECK(results(i).element_id == i);
 		}
 	};
@@ -43,7 +43,7 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 	{
 		for (int i = 0; i < results.size(); i++)
 		{
-			CHECK(results(i).dimensionality == pcms::TreePointSearch2D::Dim_t::FACE);
+			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::FACE);
 			CHECK(results(i).element_id == i);
 		}
 	};
@@ -52,7 +52,7 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 	{
 		for (int i = 0; i < results.size(); i++)
 		{
-			CHECK(results(i).dimensionality == pcms::TreePointSearch2D::Dim_t::REGION);
+			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::REGION);
 			CHECK(results(i).element_id == -1);
 		}
 	};
@@ -61,7 +61,7 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> vert_cv(
 			pcms::CoordinateSystem::Cartesian,
 			pcms::MakeConstRank2View(mesh_1x1.coords(), 2));
-		Kokkos::View<pcms::TreePointSearch2D::Result_t*> results 
+		Kokkos::View<pcms::TreePointSearch::Result*> results 
 			= tree_search.apply(vert_cv);
 		check_verts(results);
 	}
@@ -85,7 +85,7 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> edge_cv(
 			pcms::CoordinateSystem::Cartesian,
 			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 2));
-		Kokkos::View<pcms::TreePointSearch2D::Result_t*> results 
+		Kokkos::View<pcms::TreePointSearch::Result*> results 
 			= tree_search.apply(edge_cv);
 		check_edges(results);
 	}
@@ -113,7 +113,7 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> face_cv(
 			pcms::CoordinateSystem::Cartesian,
 			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 2));
-		Kokkos::View<pcms::TreePointSearch2D::Result_t*> results 
+		Kokkos::View<pcms::TreePointSearch::Result*> results 
 			= tree_search.apply(face_cv);
 		check_faces(results);
 	}
@@ -140,7 +140,7 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> outside_cv(
 			pcms::CoordinateSystem::Cartesian,
 			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 2));
-		Kokkos::View<pcms::TreePointSearch2D::Result_t*> results 
+		Kokkos::View<pcms::TreePointSearch::Result*> results 
 			= tree_search.apply(outside_cv);
 		check_outside(results);
 	}
@@ -154,17 +154,15 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 	REQUIRE(mesh_1x1.dim() == 3);
 	Omega_h::ExecSpace execs;
 	
-	pcms::TreePointSearch3D tree_search(mesh_1x1);
+	pcms::TreePointSearch tree_search(mesh_1x1);
 	// End setup for 1x1 grid test cases
 
 	auto check_verts = KOKKOS_LAMBDA (auto const& results)
 	{
 		for (int i = 0; i < mesh_1x1.nverts(); i++)
 		{
-			CHECK(results(i).dimensionality == pcms::TreePointSearch3D::Dim_t::VERTEX);
+			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::VERTEX);
 			CHECK(results(i).element_id == i);
-			CHECK_THAT(results(i).parametric_coords,
-				Catch::Matchers::Contains(Catch::Matchers::WithinAbs(1.0, 10e-7)));
 		}
 	};
 
@@ -172,7 +170,7 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 	{
 		for (int i = 0; i < mesh_1x1.nedges(); i++)
 		{
-			CHECK(results(i).dimensionality == pcms::TreePointSearch3D::Dim_t::EDGE);
+			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::EDGE);
 			CHECK(results(i).element_id == i);
 		}
 	};
@@ -181,7 +179,7 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 	{
 		for (int i = 0; i < results.size(); i++)
 		{
-			CHECK(results(i).dimensionality == pcms::TreePointSearch3D::Dim_t::FACE);
+			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::FACE);
 			CHECK(results(i).element_id == i);
 		}
 	};
@@ -190,7 +188,7 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 	{
 		for (int i = 0; i < results.size(); i++)
 		{
-			CHECK(results(i).dimensionality == pcms::TreePointSearch3D::Dim_t::REGION);
+			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::REGION);
 			CHECK(results(i).element_id == i);
 		}
 	};
@@ -199,7 +197,7 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 	{
 		for (int i = 0; i < results.size(); i++)
 		{
-			CHECK(results(i).dimensionality == pcms::TreePointSearch3D::Dim_t::REGION);
+			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::REGION);
 			CHECK(results(i).element_id == -1);
 		}
 	};
@@ -208,7 +206,7 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> vert_cv(
 			pcms::CoordinateSystem::Cartesian,
 			pcms::MakeConstRank2View(mesh_1x1.coords(), 3));
-		Kokkos::View<pcms::TreePointSearch3D::Result_t*> results 
+		Kokkos::View<pcms::TreePointSearch::Result*> results 
 			= tree_search.apply(vert_cv);
 		check_verts(results);
 	}
@@ -233,7 +231,7 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> edge_cv(
 			pcms::CoordinateSystem::Cartesian,
 			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 3));
-		Kokkos::View<pcms::TreePointSearch3D::Result_t*> results 
+		Kokkos::View<pcms::TreePointSearch::Result*> results 
 			= tree_search.apply(edge_cv);
 		check_edges(results);
 	}
@@ -262,7 +260,7 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> face_cv(
 			pcms::CoordinateSystem::Cartesian,
 			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 3));
-		Kokkos::View<pcms::TreePointSearch3D::Result_t*> results 
+		Kokkos::View<pcms::TreePointSearch::Result*> results 
 			= tree_search.apply(face_cv);
 		check_faces(results);
 	}
@@ -294,7 +292,7 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> region_cv(
 			pcms::CoordinateSystem::Cartesian,
 			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 3));
-		Kokkos::View<pcms::TreePointSearch3D::Result_t*> results 
+		Kokkos::View<pcms::TreePointSearch::Result*> results 
 			= tree_search.apply(region_cv);
 		check_regions(results);
 	}
@@ -315,7 +313,7 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> outside_cv(
 			pcms::CoordinateSystem::Cartesian,
 			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 3));
-		Kokkos::View<pcms::TreePointSearch3D::Result_t*> results 
+		Kokkos::View<pcms::TreePointSearch::Result*> results 
 			= tree_search.apply(outside_cv);
 		check_outside(results);
 	}

--- a/test/test_tree_localization.cpp
+++ b/test/test_tree_localization.cpp
@@ -48,6 +48,15 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 		}
 	};
 
+	auto check_outside = KOKKOS_LAMBDA (auto const& results)
+	{
+		for (int i = 0; i < results.size(); i++)
+		{
+			CHECK(results(i).dimensionality == pcms::TreePointSearch2D::Dim_t::REGION);
+			CHECK(results(i).element_id == -1);
+		}
+	};
+
 	SECTION ("Vertex intersection") {
 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> vert_cv(
 			pcms::CoordinateSystem::Cartesian,
@@ -107,5 +116,32 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 		Kokkos::View<pcms::TreePointSearch2D::Result_t*> results 
 			= tree_search.apply(face_cv);
 		check_faces(results);
+	}
+	SECTION("Outside Mesh") {
+		Omega_h::Write<pcms::Real> coords
+		{
+			-0.5, -0.5,
+			-0.5, 0.0,
+			-0.5, 0.5,
+			-0.5, 1.0,
+			-0.5, 1.5,
+			0.0, -0.5,
+			0.0, 1.5,
+			0.5, -0.5,
+			0.5, 1.5,
+			1.0, -0.5,
+			1.0, 1.5,
+			1.5, -0.5,
+			1.5, 0.0,
+			1.5, 0.5,
+			1.5, 1.0,
+			1.5, 1.5
+		};
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> outside_cv(
+			pcms::CoordinateSystem::Cartesian,
+			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 2));
+		Kokkos::View<pcms::TreePointSearch2D::Result_t*> results 
+			= tree_search.apply(outside_cv);
+		check_outside(results);
 	}
 }

--- a/test/test_tree_localization.cpp
+++ b/test/test_tree_localization.cpp
@@ -12,48 +12,25 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 	// Setup for 1x1 grid test cases
 	auto lib = Omega_h::Library{};
 	auto world = lib.world();
-	Omega_h::Mesh mesh_1x1 = Omega_h::build_box(world, OMEGA_H_SIMPLEX, 1, 1, 1, 1, 1, 0, false);
+	Omega_h::Mesh mesh_1x1 = Omega_h::build_box(world, OMEGA_H_SIMPLEX, 1, 1, 1, 100, 100, 0, false);
 	REQUIRE(mesh_1x1.dim() == 2);
 	Omega_h::ExecSpace execs;
 	
 	pcms::TreePointSearch tree_search(mesh_1x1);
 	// End setup for 1x1 grid test cases
 
-	auto check_verts = [] (auto const& results)
+	auto check_res = [] (auto const& results, int dim)
 	{
-		for (int i = 0; i < results.size(); i++)
+		auto dims = Kokkos::create_mirror_view(results.dimensionalities);
+		auto ids = Kokkos::create_mirror_view(results.element_ids);
+		Kokkos::deep_copy(dims, results.dimensionalities);
+		Kokkos::deep_copy(ids, results.element_ids);
+		for (int i = 0; i < dims.size(); i++)
 		{
-			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::VERTEX);
-			CHECK(results(i).element_id == i);
+			CHECK(dims(i) == (pcms::TreePointSearch::Dimensionality)dim);
+			CHECK(ids(i) == i);
 			// CHECK_THAT(results(i).parametric_coords,
 			// 	Catch::Matchers::Contains(Catch::Matchers::WithinAbs(1.0, 10e-7)));
-		}
-	};
-
-	auto check_edges = [] (auto const& results)
-	{
-		for (int i = 0; i < results.size(); i++)
-		{
-			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::EDGE);
-			CHECK(results(i).element_id == i);
-		}
-	};
-
-	auto check_faces = [] (auto const& results)
-	{
-		for (int i = 0; i < results.size(); i++)
-		{
-			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::FACE);
-			CHECK(results(i).element_id == i);
-		}
-	};
-
-	auto check_outside = [] (auto const& results)
-	{
-		for (int i = 0; i < results.size(); i++)
-		{
-			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::REGION);
-			CHECK(results(i).element_id == -1);
 		}
 	};
 
@@ -70,11 +47,8 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> vert_cv(
 			pcms::CoordinateSystem::Cartesian,
 			pcms::MakeConstRank2View(coords));
-		Kokkos::View<pcms::TreePointSearch::Result*> results 
-			= tree_search.apply(vert_cv);
-		auto results_h = Kokkos::create_mirror_view(results);
-		Kokkos::deep_copy(execs, results_h, results);
-		check_verts(results_h);
+		pcms::TreePointSearch::Results results = tree_search.apply(vert_cv);
+		check_res(results, 0);
 	}
 	SECTION ("Edge intersection") {
 		Kokkos::View<pcms::Real**, pcms::TreePointSearch::MemorySpace> coords("edge coordinates", mesh_1x1.nedges(), 2);
@@ -98,11 +72,8 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> edge_cv(
 			pcms::CoordinateSystem::Cartesian,
 			pcms::MakeConstRank2View(coords));
-		Kokkos::View<pcms::TreePointSearch::Result*> results 
-			= tree_search.apply(edge_cv);
-		auto results_h = Kokkos::create_mirror_view(results);
-		Kokkos::deep_copy(execs, results_h, results);
-		check_edges(results_h);
+		pcms::TreePointSearch::Results results = tree_search.apply(edge_cv);
+		check_res(results, 1);
 	}
 	SECTION ("Face intersection") {
 		Kokkos::View<pcms::Real**, pcms::TreePointSearch::MemorySpace> coords("face coordinates", mesh_1x1.nfaces(), 2);
@@ -129,11 +100,8 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> face_cv(
 			pcms::CoordinateSystem::Cartesian,
 			pcms::MakeConstRank2View(coords));
-		Kokkos::View<pcms::TreePointSearch::Result*> results 
-			= tree_search.apply(face_cv);
-		auto results_h = Kokkos::create_mirror_view(results);
-		Kokkos::deep_copy(execs, results_h, results);
-		check_faces(results_h);
+		pcms::TreePointSearch::Results results = tree_search.apply(face_cv);
+		check_res(results, 2);
 	}
 	// SECTION("Outside Mesh") {
 	// 	Omega_h::Write<pcms::Real> coords
@@ -155,14 +123,11 @@ TEST_CASE ("Test 1x1 2D grid point classification") {
 	// 		1.5, 1.0,
 	// 		1.5, 1.5
 	// 	};
-	// 	pcms::CoordinateView<Omega_h::ExecSpace::memory_space> outside_cv(
+	// 	pcms::CoordinateView<pcms::PointSearch::MemorySpace> outside_cv(
 	// 		pcms::CoordinateSystem::Cartesian,
-	// 		pcms::MakeConstRank2View(coords));
-	// 	Kokkos::View<pcms::TreePointSearch::Result*> results 
-	// 		= tree_search.apply(outside_cv);
-// auto results_h = Kokkos::create_mirror_view(results);
-// Kokkos::deep_copy(execs, results_h, results);
-	// 	check_outside(results_h);
+	// 		pcms::MakeConstRank2View<pcms::Real>(Omega_h::Read<pcms::Real>(coords), 2));
+	// 	pcms::TreePointSearch::Results results = tree_search.apply(outside_cv);
+	// 	check_res(results, 4);
 	// }
 }
 
@@ -170,58 +135,28 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 	// Setup for 1x1x1 grid test cases
 	auto lib = Omega_h::Library{};
 	auto world = lib.world();
-	Omega_h::Mesh mesh_1x1 = Omega_h::build_box(world, OMEGA_H_SIMPLEX, 1, 1, 1, 1, 1, 1, false);
+	Omega_h::Mesh mesh_1x1 = Omega_h::build_box(world, OMEGA_H_SIMPLEX, 1, 1, 1, 20, 20, 20, false);
 	REQUIRE(mesh_1x1.dim() == 3);
 	Omega_h::ExecSpace execs;
 	
 	pcms::TreePointSearch tree_search(mesh_1x1);
 	// End setup for 1x1 grid test cases
 
-	auto check_verts = [] (auto const& results)
+	auto check_res = [] (auto const& results, int dim)
 	{
-		for (int i = 0; i < results.size(); i++)
+		auto dims = Kokkos::create_mirror_view(results.dimensionalities);
+		auto ids = Kokkos::create_mirror_view(results.element_ids);
+		Kokkos::deep_copy(dims, results.dimensionalities);
+		Kokkos::deep_copy(ids, results.element_ids);
+		for (int i = 0; i < dims.size(); i++)
 		{
-			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::VERTEX);
-			CHECK(results(i).element_id == i);
+			CHECK(dims(i) == (pcms::TreePointSearch::Dimensionality)dim);
+			CHECK(ids(i) == i);
+			// CHECK_THAT(results(i).parametric_coords,
+			// 	Catch::Matchers::Contains(Catch::Matchers::WithinAbs(1.0, 10e-7)));
 		}
 	};
-
-	auto check_edges = [] (auto const& results)
-	{
-		for (int i = 0; i < results.size(); i++)
-		{
-			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::EDGE);
-			CHECK(results(i).element_id == i);
-		}
-	};
-
-	auto check_faces = [] (auto const& results)
-	{
-		for (int i = 0; i < results.size(); i++)
-		{
-			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::FACE);
-			CHECK(results(i).element_id == i);
-		}
-	};
-
-	auto check_regions = [] (auto const& results)
-	{
-		for (int i = 0; i < results.size(); i++)
-		{
-			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::REGION);
-			CHECK(results(i).element_id == i);
-		}
-	};
-
-	auto check_outside = [] (auto const& results)
-	{
-		for (int i = 0; i < results.size(); i++)
-		{
-			CHECK(results(i).dimensionality == pcms::TreePointSearch::Dimensionality::REGION);
-			CHECK(results(i).element_id == -1);
-		}
-	};
-
+	
 	SECTION ("Vertex intersection") {
 		Kokkos::View<pcms::Real**, pcms::TreePointSearch::MemorySpace> coords("vertex coordinates", mesh_1x1.nverts(), 3);
 		auto coords_h = Kokkos::create_mirror_view(coords);
@@ -236,12 +171,9 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> vert_cv(
 			pcms::CoordinateSystem::Cartesian,
 			pcms::MakeConstRank2View(coords));
-		Kokkos::View<pcms::TreePointSearch::Result*> results 
-			= tree_search.apply(vert_cv);
-		auto results_h = Kokkos::create_mirror_view(results);
-		Kokkos::deep_copy(execs, results_h, results);
+		pcms::TreePointSearch::Results results = tree_search.apply(vert_cv);
 		
-		check_verts(results_h);
+		check_res(results, 0);
 	}
 	SECTION ("Edge intersection") {
 		Kokkos::View<pcms::Real**, pcms::TreePointSearch::MemorySpace> coords("intersection coords", mesh_1x1.nedges(), 3);
@@ -268,11 +200,8 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> edge_cv(
 			pcms::CoordinateSystem::Cartesian,
 			pcms::MakeConstRank2View(coords));
-		Kokkos::View<pcms::TreePointSearch::Result*> results 
-			= tree_search.apply(edge_cv);
-		auto results_h = Kokkos::create_mirror_view(results);
-		Kokkos::deep_copy(execs, results_h, results);
-		check_edges(results_h);
+		pcms::TreePointSearch::Results results = tree_search.apply(edge_cv);
+		check_res(results, 1);
 	}
 	SECTION ("Face intersection") {
 		Kokkos::View<pcms::Real**, pcms::TreePointSearch::MemorySpace> coords("intersection coords", mesh_1x1.nfaces(), 3);
@@ -301,11 +230,8 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> face_cv(
 			pcms::CoordinateSystem::Cartesian,
 			pcms::MakeConstRank2View(coords));
-		Kokkos::View<pcms::TreePointSearch::Result*> results 
-			= tree_search.apply(face_cv);
-		auto results_h = Kokkos::create_mirror_view(results);
-		Kokkos::deep_copy(execs, results_h, results);
-		check_faces(results_h);
+		pcms::TreePointSearch::Results results = tree_search.apply(face_cv);
+		check_res(results, 2);
 	}
 	SECTION ("Region intersection") {
 		Kokkos::View<pcms::Real**, pcms::TreePointSearch::MemorySpace> coords("intersection coords", mesh_1x1.nelems(), 3);
@@ -337,11 +263,8 @@ TEST_CASE ("Test 1x1x1 3D grid point classification") {
 		pcms::CoordinateView<Omega_h::ExecSpace::memory_space, pcms::detail::default_layout_for_memory_space_t<Omega_h::ExecSpace::memory_space>> region_cv(
 			pcms::CoordinateSystem::Cartesian,
 			pcms::MakeConstRank2View(coords));
-		Kokkos::View<pcms::TreePointSearch::Result*> results 
-			= tree_search.apply(region_cv);
-		auto results_h = Kokkos::create_mirror_view(results);
-		Kokkos::deep_copy(execs, results_h, results);
-		check_regions(results_h);
+		pcms::TreePointSearch::Results results = tree_search.apply(region_cv);
+		check_res(results, 3);
 	}
 
 	// SECTION ("Region intersection") {

--- a/test/test_tree_localization.cpp
+++ b/test/test_tree_localization.cpp
@@ -1,0 +1,77 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_contains.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <Omega_h_mesh.hpp>
+#include <Omega_h_build.hpp>
+
+#include <pcms/localization/point_localization.h>
+
+TEST_CASE ("Test 1x1 2D grid point classification") {
+	// Setup for 1x1 grid test cases
+	auto lib = Omega_h::Library{};
+	auto world = lib.world();
+	Omega_h::Mesh mesh_1x1 = Omega_h::build_box(world, OMEGA_H_SIMPLEX, 1, 1, 1, 1, 1, 0, false);
+	REQUIRE(mesh_1x1.dim() == 2);
+	Omega_h::ExecSpace execs;
+	
+	pcms::TreePointSearch2D tree_search(mesh_1x1);
+	// End setup for 1x1 grid test cases
+
+	auto check_verts = KOKKOS_LAMBDA (auto const& results)
+	{
+		for (int i = 0; i < mesh_1x1.nverts(); i++)
+		{
+			CHECK(results(i).dimensionality == pcms::TreePointSearch2D::Dim_t::VERTEX);
+			CHECK(results(i).element_id == i);
+			CHECK_THAT(results(i).parametric_coords,
+				Catch::Matchers::Contains(Catch::Matchers::WithinAbs(1.0, 10e-7)));
+		}
+	};
+
+	auto check_edges = KOKKOS_LAMBDA (auto const& results)
+	{
+		for (int i = 0; i < mesh_1x1.nedges(); i++)
+		{
+			CHECK(results(i).dimensionality == pcms::TreePointSearch2D::Dim_t::EDGE);
+			CHECK(results(i).element_id == i);
+		}
+	};
+
+	SECTION ("Vertex intersection") {
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> vert_cv(
+			pcms::CoordinateSystem::Cartesian,
+			pcms::MakeConstRank2View(mesh_1x1.coords(), 2));
+		Kokkos::View<pcms::TreePointSearch2D::Result_t*> results 
+			= tree_search.apply(vert_cv);
+		check_verts(results);
+	}
+	SECTION ("Edge intersection") {
+		Omega_h::Write<pcms::Real> coords(mesh_1x1.nedges()*2);
+		auto edge2vert = mesh_1x1.get_adj(Omega_h::EDGE, Omega_h::VERT).ab2b;
+		auto meshcoords = mesh_1x1.coords();
+		for (int i = 0; i < mesh_1x1.nedges(); i++)
+		{
+			Omega_h::Vector<2> v0{
+				meshcoords[edge2vert[2*i]*2], meshcoords[edge2vert[2*i]*2 + 1]
+			};
+			Omega_h::Vector<2> v1{
+				meshcoords[edge2vert[2*i + 1]*2], meshcoords[edge2vert[2*i + 1]*2 + 1]
+			};
+			Omega_h::Vector<2> midpoint = (v0 + v1)/2.;
+			coords[i*2] = midpoint[0];
+			coords[i*2 + 1] = midpoint[1];
+		}
+
+		pcms::CoordinateView<Omega_h::ExecSpace::memory_space> edge_cv(
+			pcms::CoordinateSystem::Cartesian,
+			pcms::MakeConstRank2View(Omega_h::Read<pcms::Real>(coords), 2));
+		Kokkos::View<pcms::TreePointSearch2D::Result_t*> results 
+			= tree_search.apply(edge_cv);
+		check_edges(results);
+	}
+	SECTION ("Face intersection") {
+		
+	}
+}


### PR DESCRIPTION
This PR uses `ArborX::BVH` to provide accelerated point localization and refactors the previous localization API (`pcms::PointLocalizationSearch`) to no longer use templates.